### PR TITLE
Fix tarball compressor test on OSX

### DIFF
--- a/fileutil/tarball_compressor_test.go
+++ b/fileutil/tarball_compressor_test.go
@@ -88,7 +88,10 @@ var _ = Describe("tarballCompressor", func() {
 	BeforeEach(func() {
 		if runtime.GOOS == "windows" {
 			Skip("Pending on Windows")
+		} else if runtime.GOOS == "darwin" {
+			os.Setenv("COPYFILE_DISABLE", "1") // fix for bsd/osx tar: http://superuser.com/a/260264
 		}
+
 		fs.MkdirAll(dstDir, os.ModePerm)
 	})
 


### PR DESCRIPTION
On my machine the tarball_compressor_test:124 fails with:

```
• Failure [0.061 seconds]
tarballCompressor
/Users/mossity/workspace/bosh-agent-workspace/src/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor_test.go:237
  CompressFilesInDir
  /Users/mossity/workspace/bosh-agent-workspace/src/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor_test.go:141
    compresses the files in the given directory [It]
    /Users/mossity/workspace/bosh-agent-workspace/src/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor_test.go:140

    Expected
        <[]string | len:24, cap:24>: [
            "./._.",
            "./",
            "./._app.stderr.log",
            "./app.stderr.log",
            "./._app.stdout.log",
            "./app.stdout.log",
            "./._other_logs",
            "./other_logs/",
            "./._some_directory",
            "./some_directory/",
            "./some_directory/._sub_dir",
            "./some_directory/sub_dir/",
            "./some_directory/sub_dir/._other_sub_dir",
            "./some_directory/sub_dir/other_sub_dir/",
            "./some_directory/sub_dir/other_sub_dir/._.keep",
            "./some_directory/sub_dir/other_sub_dir/.keep",
            "./other_logs/._more_logs",
            "./other_logs/more_logs/",
            "./other_logs/._other_app.stderr.log",
            "./other_logs/other_app.stderr.log",
            "./other_logs/._other_app.stdout.log",
            "./other_logs/other_app.stdout.log",
            "./other_logs/more_logs/._more.stdout.log",
            "./other_logs/more_logs/more.stdout.log",
        ]
    to consist of
        <[]interface {} | len:12, cap:12>: [
            "./",
            "./app.stderr.log",
            "./app.stdout.log",
            "./other_logs/",
            "./some_directory/",
            "./some_directory/sub_dir/",
            "./some_directory/sub_dir/other_sub_dir/",
            "./some_directory/sub_dir/other_sub_dir/.keep",
            "./other_logs/more_logs/",
            "./other_logs/other_app.stderr.log",
            "./other_logs/other_app.stdout.log",
            "./other_logs/more_logs/more.stdout.log",
        ]

    /Users/mossity/workspace/bosh-agent-workspace/src/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor_test.go:124
```

It looks like setting [this undocumented environment variable](https://superuser.com/questions/259703/get-mac-tar-to-stop-putting-filenames-in-tar-archives) on the test process and OSX/BSD tar will not create these extra underscore files. Since I'm soloing today figured I'd get some review. 

Do we care about being able to run on OSX? How are the OSX dev machines at Pivotal working around this test?