### PR TITLE
Display file permissions as octal number in bosh-agent logs

### DIFF
--- a/system/os_file_system.go
+++ b/system/os_file_system.go
@@ -69,7 +69,7 @@ func (fs *osFileSystem) ExpandPath(path string) (string, error) {
 }
 
 func (fs *osFileSystem) MkdirAll(path string, perm os.FileMode) (err error) {
-	fs.logger.Debug(fs.logTag, "Making dir %s with perm %d", path, perm)
+	fs.logger.Debug(fs.logTag, "Making dir %s with perm %#o", path, perm)
 	return os.MkdirAll(path, perm)
 }
 


### PR DESCRIPTION
In this PR, I suggest a proper way to output permissions for files that are created by the bosh-agent.
Indeed, those are currently displayed as decimal number, which doesn't make sense because such permissions are typically octal numbers.

Cheers