### PR TITLE
Bump TLS Timeout from 10 to 30 seconds

### DIFF
--- a/httpclient/http_client.go
+++ b/httpclient/http_client.go
@@ -35,7 +35,7 @@ func CreateDefaultClient() http.Client {
 				Timeout:   30 * time.Second,
 				KeepAlive: 0,
 			}).Dial,
-			TLSHandshakeTimeout: 10 * time.Second,
+			TLSHandshakeTimeout: 30 * time.Second,
 			DisableKeepAlives:   true,
 		},
 	}


### PR DESCRIPTION
- We saw this timeout frequently when deploying to China via bosh-init
- Tested with the higher timeout and pipelines were more stable
- Once this is merged, we need to bump this lib in bosh-init / bosh-agent client

[#125366561](https://www.pivotaltracker.com/story/show/125366561)