### PR TITLE
Allow customized Delete requests

### DIFF
--- a/httpclient/http_client.go
+++ b/httpclient/http_client.go
@@ -23,6 +23,7 @@ type HTTPClient interface {
 	GetCustomized(endpoint string, f func(*http.Request)) (*http.Response, error)
 
 	Delete(endpoint string) (*http.Response, error)
+	DeleteCustomized(endpoint string, f func(*http.Request)) (*http.Response, error)
 }
 
 type httpClient struct {
@@ -148,6 +149,10 @@ func (c httpClient) GetCustomized(endpoint string, f func(*http.Request)) (*http
 }
 
 func (c httpClient) Delete(endpoint string) (*http.Response, error) {
+	return c.DeleteCustomized(endpoint, nil)
+}
+
+func (c httpClient) DeleteCustomized(endpoint string, f func(*http.Request)) (*http.Response, error) {
 	redactedEndpoint := endpoint
 
 	if !c.opts.NoRedactUrlQuery {
@@ -159,6 +164,10 @@ func (c httpClient) Delete(endpoint string) (*http.Response, error) {
 	request, err := http.NewRequest("DELETE", endpoint, nil)
 	if err != nil {
 		return nil, bosherr.WrapError(err, "Creating DELETE request")
+	}
+
+	if f != nil {
+		f(request)
 	}
 
 	response, err := c.client.Do(request)

--- a/httpclient/http_client_test.go
+++ b/httpclient/http_client_test.go
@@ -209,7 +209,31 @@ var _ = Describe("HTTPClient", func() {
 		})
 	})
 
-	Describe("Delete", func() {
+	Describe("Delete/DeleteCustomized", func() {
+		It("allows to override request", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("DELETE", "/path"),
+					ghttp.VerifyHeader(http.Header{
+						"X-Custom": []string{"custom"},
+					}),
+					ghttp.RespondWith(http.StatusOK, ""),
+				),
+			)
+
+			url := server.URL() + "/path"
+
+			setHeaders := func(r *http.Request) {
+				r.Header.Add("X-Custom", "custom")
+			}
+
+			response, err := httpClient.DeleteCustomized(url, setHeaders)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(200))
+
+			Expect(server.ReceivedRequests()).To(HaveLen(1))
+		})
+
 		Describe("httpclient opts", func() {
 			var opts Opts
 


### PR DESCRIPTION
In support of [this story](https://www.pivotaltracker.com/n/projects/956238/stories/134702861). We are adding a `X-Bosh-Context-Id` to requests to group bosh tasks. This change would allow us to use `DeleteCustomized` to add the header for all delete requests in the Bosh Go CLI.

cc: @avade