### PR TITLE
Add `Get` methods to HTTP `RetryClient` for convenience

### DIFF
--- a/http/retry_clients_test.go
+++ b/http/retry_clients_test.go
@@ -1,32 +1,36 @@
 package http_test
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	fakehttp "github.com/cloudfoundry/bosh-utils/http/fakes"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 
+	. "github.com/cloudfoundry/bosh-utils/http"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"fmt"
-
-	. "github.com/cloudfoundry/bosh-utils/http"
 )
 
 var _ = Describe("RetryClients", func() {
 
+	var logger boshlog.Logger
+
+	BeforeEach(func() {
+		logger = boshlog.NewLogger(boshlog.LevelNone)
+	})
+
 	Describe("RetryClient", func() {
 		Describe("Do", func() {
 			var (
-				retryClient Client
+				retryClient RetryClient
 				maxAttempts int
 				fakeClient  *fakehttp.FakeClient
 			)
 
 			BeforeEach(func() {
 				fakeClient = fakehttp.NewFakeClient()
-				logger := boshlog.NewLogger(boshlog.LevelNone)
 				maxAttempts = 7
 
 				retryClient = NewRetryClient(fakeClient, uint(maxAttempts), 0, logger)
@@ -74,14 +78,13 @@ var _ = Describe("RetryClients", func() {
 	Describe("NetworkSafeClient", func() {
 		Describe("Do", func() {
 			var (
-				retryClient Client
+				retryClient RetryClient
 				maxAttempts int
 				fakeClient  *fakehttp.FakeClient
 			)
 
 			BeforeEach(func() {
 				fakeClient = fakehttp.NewFakeClient()
-				logger := boshlog.NewLogger(boshlog.LevelNone)
 				maxAttempts = 7
 
 				retryClient = NewNetworkSafeRetryClient(fakeClient, uint(maxAttempts), 0, logger)
@@ -156,4 +159,87 @@ var _ = Describe("RetryClients", func() {
 
 	})
 
+	Describe("Get", func() {
+		var (
+			retryClient RetryClient
+			fakeClient  *fakehttp.FakeClient
+		)
+
+		maxAttempts := 2
+
+		Context("when server fails more often than maxAttempts", func() {
+
+			BeforeEach(func() {
+				fakeClient = fakehttp.NewFakeClient()
+				retryClient = NewRetryClient(fakeClient, uint(maxAttempts), 0, logger)
+			})
+
+			It("fails after maxAttempts", func() {
+				fakeClient.StatusCode = 500
+				fakeClient.Error = errors.New("Some error")
+
+				resp, err := retryClient.Get("some url")
+				Expect(err).To(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(500))
+				Expect(err.Error()).To(Equal("Some error"))
+				Expect(fakeClient.CallCount).To(Equal(maxAttempts))
+			})
+
+		})
+
+		Context("when server succeeds within maxAttempts", func() {
+
+			BeforeEach(func() {
+				fakeClient = fakehttp.NewFakeClient()
+				fakeClient.AddDoBehavior(
+					&http.Response{
+						Body:       NewStringReadCloser("error"),
+						StatusCode: 500,
+					},
+					errors.New("error"),
+				)
+				fakeClient.AddDoBehavior(
+					&http.Response{
+						Body:       NewStringReadCloser("success"),
+						StatusCode: 200,
+					},
+					nil,
+				)
+
+				retryClient = NewRetryClient(fakeClient, uint(maxAttempts), 0, logger)
+			})
+
+			It("succeeds", func() {
+				fakeClient.StatusCode = 200
+
+				resp, err := retryClient.Get("some url")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(200))
+				Expect(fakeClient.CallCount).To(Equal(maxAttempts))
+			})
+		})
+	})
+
+	Describe("GetWithHeaders", func() {
+		var (
+			retryClient RetryClient
+			fakeClient  *fakehttp.FakeClient
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakehttp.NewFakeClient()
+			retryClient = NewRetryClient(fakeClient, 1, 0, logger)
+		})
+
+		It("sends headers", func() {
+			headers := map[string]string{
+				"foo": "bar",
+			}
+			retryClient.GetWithHeaders("some url", headers)
+			Expect(fakeClient.Requests[0].Header).To(Equal(http.Header{
+				"Foo": []string{"bar"},
+			}))
+		})
+
+	})
 })


### PR DESCRIPTION
We plan to use those methods in multiple places in bosh-agent.
Please merge and bump in bosh-agent.
We don't have write permissions for this repository, so we could not do it ourselves.

[#135338075](https://www.pivotaltracker.com/story/show/135338075)

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>