### PR TITLE
Attempt to make tar work on Windows

### DIFF
--- a/fileutil/tarball_compressor.go
+++ b/fileutil/tarball_compressor.go
@@ -1,7 +1,6 @@
 package fileutil
 
 import (
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 )
 
@@ -19,42 +18,6 @@ func NewTarballCompressor(
 
 func (c tarballCompressor) CompressFilesInDir(dir string) (string, error) {
 	return c.CompressSpecificFilesInDir(dir, []string{"."})
-}
-
-func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
-	tarball, err := c.fs.TempFile("bosh-platform-disk-TarballCompressor-CompressSpecificFilesInDir")
-	if err != nil {
-		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
-	}
-
-	tarballPath := tarball.Name()
-
-	args := []string{"czf", tarballPath, "-C", dir}
-
-	for _, file := range files {
-		args = append(args, file)
-	}
-
-	_, _, _, err = c.cmdRunner.RunCommand("tar", args...)
-	if err != nil {
-		return "", bosherr.WrapError(err, "Shelling out to tar")
-	}
-
-	return tarballPath, nil
-}
-
-func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, options CompressorOptions) error {
-	sameOwnerOption := "--no-same-owner"
-	if options.SameOwner {
-		sameOwnerOption = "--same-owner"
-	}
-
-	_, _, _, err := c.cmdRunner.RunCommand("tar", sameOwnerOption, "-xzvf", tarballPath, "-C", dir)
-	if err != nil {
-		return bosherr.WrapError(err, "Shelling out to tar")
-	}
-
-	return nil
 }
 
 func (c tarballCompressor) CleanUp(tarballPath string) error {

--- a/fileutil/tarball_compressor_unix.go
+++ b/fileutil/tarball_compressor_unix.go
@@ -12,6 +12,8 @@ func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string
 		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
 	}
 
+	defer tarball.Close()
+
 	tarballPath := tarball.Name()
 
 	args := []string{"czf", tarballPath, "-C", dir}

--- a/fileutil/tarball_compressor_unix.go
+++ b/fileutil/tarball_compressor_unix.go
@@ -1,0 +1,43 @@
+// +build !windows
+
+package fileutil
+
+import (
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+)
+
+func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
+	tarball, err := c.fs.TempFile("bosh-platform-disk-TarballCompressor-CompressSpecificFilesInDir")
+	if err != nil {
+		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
+	}
+
+	tarballPath := tarball.Name()
+
+	args := []string{"czf", tarballPath, "-C", dir}
+
+	for _, file := range files {
+		args = append(args, file)
+	}
+
+	_, _, _, err = c.cmdRunner.RunCommand("tar", args...)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Shelling out to tar")
+	}
+
+	return tarballPath, nil
+}
+
+func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, options CompressorOptions) error {
+	sameOwnerOption := "--no-same-owner"
+	if options.SameOwner {
+		sameOwnerOption = "--same-owner"
+	}
+
+	_, _, _, err := c.cmdRunner.RunCommand("tar", sameOwnerOption, "-xzvf", tarballPath, "-C", dir)
+	if err != nil {
+		return bosherr.WrapError(err, "Shelling out to tar")
+	}
+
+	return nil
+}

--- a/fileutil/tarball_compressor_windows.go
+++ b/fileutil/tarball_compressor_windows.go
@@ -1,0 +1,77 @@
+// +build windows
+
+package fileutil
+
+import (
+	"regexp"
+	"strings"
+
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+)
+
+func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
+	tarball, err := c.fs.TempFile("bosh-platform-disk-TarballCompressor-CompressSpecificFilesInDir")
+	if err != nil {
+		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
+	}
+
+	tarballPath := tarball.Name()
+
+	tarballPathForTar, err := makePathTarCompatible(tarballPath)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Converting tarballPath path failed")
+	}
+	dir, err = makePathTarCompatible(dir)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Converting dir path failed")
+	}
+
+	args := []string{"czf", tarballPathForTar, "-C", dir}
+
+	for _, file := range files {
+		args = append(args, file)
+	}
+
+	_, _, _, err = c.cmdRunner.RunCommand("tar", args...)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Shelling out to tar")
+	}
+
+	return tarballPath, nil
+}
+
+func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, options CompressorOptions) error {
+	sameOwnerOption := "--no-same-owner"
+	if options.SameOwner {
+		sameOwnerOption = "--same-owner"
+	}
+
+	tarballPath, err := makePathTarCompatible(tarballPath)
+	if err != nil {
+		return bosherr.WrapError(err, "Converting tarballPath path failed")
+	}
+	dir, err = makePathTarCompatible(dir)
+	if err != nil {
+		return bosherr.WrapError(err, "Converting dir path failed")
+	}
+
+	_, _, _, err = c.cmdRunner.RunCommand("tar", sameOwnerOption, "-xzvf", tarballPath, "-C", dir)
+	if err != nil {
+		return bosherr.WrapError(err, "Shelling out to tar")
+	}
+
+	return nil
+}
+
+func makePathTarCompatible(path string) (string, error) {
+	doesPathContainDrive, err := regexp.MatchString("^[a-zA-Z]:", path)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Test for drive in path failed")
+	}
+	if doesPathContainDrive {
+		path = "/" + string(path[0]) + string(path[2:])
+	}
+	path = strings.Replace(path, "\\", "/", -1)
+
+	return path, nil
+}

--- a/fileutil/tarball_compressor_windows.go
+++ b/fileutil/tarball_compressor_windows.go
@@ -57,7 +57,7 @@ func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, o
 		return bosherr.WrapError(err, "Converting dir path failed")
 	}
 
-	_, _, _, err = c.cmdRunner.RunCommand("tar", sameOwnerOption, "-xzvf", tarballPath, "-C", dir)
+	_, _, _, err = c.cmdRunner.RunCommand("tar", sameOwnerOption, "-xzf", tarballPath, "-C", dir)
 	if err != nil {
 		return bosherr.WrapError(err, "Shelling out to tar")
 	}

--- a/fileutil/tarball_compressor_windows.go
+++ b/fileutil/tarball_compressor_windows.go
@@ -15,6 +15,8 @@ func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string
 		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
 	}
 
+	defer tarball.Close()
+
 	tarballPath := tarball.Name()
 
 	tarballPathForTar, err := makePathTarCompatible(tarballPath)


### PR DESCRIPTION
The `tar` commandline requires changes to the path for it to work on Windows. As a result I moved `CompressSpecificFilesInDir` and `DecompressFileToDir` into separate Windows and non Windows build files. I also split the tests into separate Windows and non Windows build files, so that they will be able to run build specific tests. All the tests in `fileutil` are passing on Windows.

I'm still new to Go, so please let me know how I can improve this.

As `tar` isn't available on Windows by default, so #9 is still advised, but these changes should enable the version of `tar` that comes with [Git][1] to work.

[1]: https://git-scm.com/