### PR TITLE
Enable TCP keepalives for outbound connections

### DIFF
--- a/httpclient/default_http_clients.go
+++ b/httpclient/default_http_clients.go
@@ -29,7 +29,7 @@ type factory struct{}
 func (f factory) New(insecureSkipVerify bool, certPool *x509.CertPool) *http.Client {
 	defaultDialer := &net.Dialer{
 		Timeout:   30 * time.Second,
-		KeepAlive: 0,
+		KeepAlive: 30 * time.Second,
 	}
 
 	client := &http.Client{

--- a/httpclient/default_http_clients_test.go
+++ b/httpclient/default_http_clients_test.go
@@ -8,6 +8,10 @@ import (
 
 	. "github.com/cloudfoundry/bosh-utils/httpclient"
 	"github.com/cloudfoundry/bosh-utils/httpclient/fakes"
+	"net"
+	"syscall"
+	"os"
+	"time"
 )
 
 var _ HTTPClient = &fakes.FakeHTTPClient{}
@@ -20,11 +24,58 @@ var _ = Describe("Default HTTP clients", func() {
 			Expect(client).To(Equal(DefaultClient))
 		})
 
-		It("disables keep alive", func() {
+		It("disables HTTP Transport keep-alive (disables HTTP/1.[01] connection reuse)", func() {
 			var client *http.Client
 			client = DefaultClient
 
 			Expect(client.Transport.(*http.Transport).DisableKeepAlives).To(Equal(true))
+		})
+
+		It("enables TCP (socket) keepalive with an appropriate interval", func() {
+			// to test keepalive, we need a socket. A socket is an _active_ TCP connection to a server.
+			// we make our own server, connect to it, and make our assertions against the socket
+			laddr := "127.0.0.1:19642" // unlikely-to-be-used port number, unprivileged (1964, Feb, my birth)
+			go func() {
+				ln, err := net.Listen("tcp", laddr)
+				if err != nil {
+					panic("I couldn't Listen() to " + laddr)
+				}
+				_, err = ln.Accept()
+				if err != nil {
+					panic("I couldn't Accept() " + laddr)
+				}
+			}()
+			// we give the server a head-start before we try to connect to it
+			time.Sleep(1 * time.Millisecond)
+			client := DefaultClient
+			connection, err := client.Transport.(*http.Transport).Dial("tcp", laddr)
+			if err != nil {
+				panic("I couldn't Dial() " + laddr)
+			}
+
+			tcpConn, ok := connection.(*net.TCPConn)
+			if !ok {
+				panic("I couldn't cast to TCPConn")
+			}
+
+			f, err := tcpConn.File()
+			if err != nil {
+				panic("I couldn't File()")
+			}
+
+			sockoptValue, err := syscall.GetsockoptInt(int(f.Fd()), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE)
+			err = os.NewSyscallError("getsockopt", err)
+			if err != nil {
+				panic("I couldn't GetsockoptInt()")
+			}
+			Expect(sockoptValue).To(Equal(syscall.SO_KEEPALIVE))
+
+			sockoptValue, err = syscall.GetsockoptInt(int(f.Fd()), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE)
+			err = os.NewSyscallError("getsockopt", err)
+			if err != nil {
+				panic("I couldn't GetsockoptInt()")
+			}
+			Expect(sockoptValue).To(Equal(30))
 		})
 	})
 


### PR DESCRIPTION
We saw a 4 day old idle connection in prod, and this should avoid that
in the future

[#143754851](https://www.pivotaltracker.com/story/show/143754851)

Signed-off-by: Chris Dutra <cdutra@pivotal.io>