### PR TITLE
Run keepalive test exclusively on Linux

### DIFF
--- a/httpclient/default_http_clients_test.go
+++ b/httpclient/default_http_clients_test.go
@@ -8,61 +8,11 @@ import (
 
 	. "github.com/cloudfoundry/bosh-utils/httpclient"
 	"github.com/cloudfoundry/bosh-utils/httpclient/fakes"
-	"syscall"
-	"net"
-	"os"
-	"runtime"
 )
 
 var _ HTTPClient = &fakes.FakeHTTPClient{}
 
 var _ = Describe("Default HTTP clients", func() {
-	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-		It("enables TCP (socket) keepalive with an appropriate interval", func() {
-			// to test keepalive, we need a socket. A socket is an _active_ TCP connection to a server.
-			// we make our own server, connect to it, and make our assertions against the socket
-			laddr := "127.0.0.1:19642" // unlikely-to-be-used port number, unprivileged (1964, Feb, my birth)
-			readyToAccept := make(chan bool, 1)
-
-			go func() {
-				defer GinkgoRecover()
-				defer func(){
-					readyToAccept<-true
-				}()
-
-				ln, err := net.Listen("tcp", laddr)
-				Expect(err).ToNot(HaveOccurred())
-
-				readyToAccept<-true
-
-				_, err = ln.Accept()
-				Expect(err).ToNot(HaveOccurred())
-			}()
-
-			<-readyToAccept
-
-			client := CreateDefaultClient(nil)
-			connection, err := client.Transport.(*http.Transport).Dial("tcp", laddr)
-			Expect(err).ToNot(HaveOccurred())
-
-			tcpConn, ok := connection.(*net.TCPConn)
-			Expect(ok).To(BeTrue())
-
-			f, err := tcpConn.File()
-			Expect(err).ToNot(HaveOccurred())
-
-			sockoptValue, err := syscall.GetsockoptInt(int(f.Fd()), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE)
-			err = os.NewSyscallError("getsockopt", err)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sockoptValue).To(Equal(keepaliveGetsockoptPlatformIndependent))
-
-			sockoptValue, err = syscall.GetsockoptInt(int(f.Fd()), syscall.IPPROTO_TCP, keepaliveIntervalPlatformIndependent)
-			err = os.NewSyscallError("getsockopt", err)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sockoptValue).To(Equal(30))
-		})
-	}
-
 	Describe("DefaultClient", func() {
 		It("is a singleton http client", func() {
 			client := DefaultClient

--- a/httpclient/keepalive_syscall_darwin_test.go
+++ b/httpclient/keepalive_syscall_darwin_test.go
@@ -1,6 +1,0 @@
-package httpclient_test
-
-import "syscall"
-
-const keepaliveIntervalPlatformIndependent = syscall.TCP_KEEPALIVE
-const keepaliveGetsockoptPlatformIndependent = syscall.SO_KEEPALIVE

--- a/httpclient/keepalive_syscall_linux_test.go
+++ b/httpclient/keepalive_syscall_linux_test.go
@@ -1,6 +1,62 @@
 package httpclient_test
 
-import "syscall"
+import (
+	"net/http"
 
-const keepaliveIntervalPlatformIndependent = syscall.TCP_KEEPINTVL
-const keepaliveGetsockoptPlatformIndependent = 0x1
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-utils/httpclient"
+	"github.com/cloudfoundry/bosh-utils/httpclient/fakes"
+	"net"
+	"os"
+	"syscall"
+)
+
+var _ HTTPClient = &fakes.FakeHTTPClient{}
+
+var _ = Describe("Linux-specific tests", func() {
+	It("enables TCP (socket) keepalive with an appropriate interval", func() {
+		// to test keepalive, we need a socket. A socket is an _active_ TCP connection to a server.
+		// we make our own server, connect to it, and make our assertions against the socket
+		laddr := "127.0.0.1:19642" // unlikely-to-be-used port number, unprivileged (1964, Feb, my birth)
+		readyToAccept := make(chan bool, 1)
+
+		go func() {
+			defer GinkgoRecover()
+			defer func() {
+				readyToAccept <- true
+			}()
+
+			ln, err := net.Listen("tcp", laddr)
+			Expect(err).ToNot(HaveOccurred())
+
+			readyToAccept <- true
+
+			_, err = ln.Accept()
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		<-readyToAccept
+
+		client := CreateDefaultClient(nil)
+		connection, err := client.Transport.(*http.Transport).Dial("tcp", laddr)
+		Expect(err).ToNot(HaveOccurred())
+
+		tcpConn, ok := connection.(*net.TCPConn)
+		Expect(ok).To(BeTrue())
+
+		f, err := tcpConn.File()
+		Expect(err).ToNot(HaveOccurred())
+
+		sockoptValue, err := syscall.GetsockoptInt(int(f.Fd()), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE)
+		err = os.NewSyscallError("getsockopt", err)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sockoptValue).To(Equal(0x1))
+
+		sockoptValue, err = syscall.GetsockoptInt(int(f.Fd()), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL)
+		err = os.NewSyscallError("getsockopt", err)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sockoptValue).To(Equal(30))
+	})
+})

--- a/system/fakes/fake_file_system.go
+++ b/system/fakes/fake_file_system.go
@@ -98,13 +98,13 @@ type FakeFileSystem struct {
 type FakeFileStats struct {
 	FileType FakeFileType
 
-	FileMode os.FileMode
-	Flags    int
-	Username string
+	FileMode  os.FileMode
+	Flags     int
+	Username  string
 	Groupname string
 
 	ModTime time.Time
-	Open bool
+	Open    bool
 
 	SymlinkTarget string
 


### PR DESCRIPTION
- keepalive tests are specified at compile time, not runtime

fixes (Windows)
```
httpclient\httpclient\default_http_clients_test.go:54: cannot use int(f.Fd()) (type int) as type syscall.Handle in argument to syscall.GetsockoptInt
httpclient\httpclient\default_http_clients_test.go:57: undefined: keepaliveGetsockoptPlatformIndependent
httpclient\httpclient\default_http_clients_test.go:59: undefined: keepaliveIntervalPlatformIndependent
httpclient\httpclient\default_http_clients_test.go:59: cannot use int(f.Fd()) (type int) as type syscall.Handle in argument to syscall.GetsockoptInt
```

[#143754851](https://www.pivotaltracker.com/story/show/143754851)

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>