### PR TITLE
Disable HTTP/2

### DIFF
--- a/httpclient/default_http_clients.go
+++ b/httpclient/default_http_clients.go
@@ -34,6 +34,7 @@ func (f factory) New(insecureSkipVerify bool, certPool *x509.CertPool) *http.Cli
 
 	client := &http.Client{
 		Transport: &http.Transport{
+			TLSNextProto: map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
 			TLSClientConfig: &tls.Config{
 				RootCAs:            certPool,
 				InsecureSkipVerify: insecureSkipVerify,

--- a/httpclient/default_http_clients_test.go
+++ b/httpclient/default_http_clients_test.go
@@ -26,6 +26,14 @@ var _ = Describe("Default HTTP clients", func() {
 
 			Expect(client.Transport.(*http.Transport).DisableKeepAlives).To(Equal(true))
 		})
+
+		It("disables HTTP/2", func() {
+			var client *http.Client
+			client = DefaultClient
+
+			Expect(client.Transport.(*http.Transport).TLSNextProto).ToNot(BeNil())
+			Expect(client.Transport.(*http.Transport).TLSNextProto).To(BeEmpty())
+		})
 	})
 
 	Describe("CreateDefaultClient", func() {


### PR DESCRIPTION
This fixes potential errors when server uses HTTP/2

error:
```
stream error: stream ID 1; PROTOCOL_ERROR
```

[#145168591](https://www.pivotaltracker.com/story/show/145168591)