### PR TITLE
UnmarshalYAML for property.Map

### DIFF
--- a/property/map.go
+++ b/property/map.go
@@ -1,3 +1,18 @@
 package property
 
 type Map map[string]Property
+
+func (m *Map) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	rawMap := map[interface{}]interface{}{}
+	err := unmarshal(&rawMap)
+	if err != nil {
+		return err
+	}
+
+	*m, err = BuildMap(rawMap)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/property/map_test.go
+++ b/property/map_test.go
@@ -1,0 +1,25 @@
+package property_test
+
+import (
+	. "github.com/cloudfoundry/bosh-utils/property"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+)
+
+var _ = Describe("Map", func() {
+	It("can be unmarshaled from yaml", func() {
+		expectedMap := Map{"foo": Map{"bar": List{"baz", "asdf"}}}
+
+		inputYAML := `
+foo:
+  bar:
+    - baz
+    - asdf
+`
+		target := Map{}
+		err := yaml.Unmarshal([]byte(inputYAML), &target)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(target).To(Equal(expectedMap))
+	})
+})

--- a/property/suite_test.go
+++ b/property/suite_test.go
@@ -1,0 +1,12 @@
+package property_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestReg(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "property")
+}

--- a/system/fakes/fake_file_system.go
+++ b/system/fakes/fake_file_system.go
@@ -802,9 +802,11 @@ func (fs *FakeFileSystem) removeAll(path string) error {
 
 func (fs *FakeFileSystem) Glob(pattern string) (matches []string, err error) {
 	if fs.GlobStub != nil {
-		_, err = fs.GlobStub(pattern)
+		matches, err = fs.GlobStub(pattern)
 		if err != nil {
 			return nil, err
+		} else {
+			return matches, nil
 		}
 	}
 


### PR DESCRIPTION
property.Map needs to implement UnmarshalYAML because the bosh-cli will make use of this map when it unmarshals the stemcell.MF as part of the story [#144851625](https://www.pivotaltracker.com/story/show/144851625).