### PR TITLE
Added dialer to accept arbitrary proxy strings

### DIFF
--- a/httpclient/socksify.go
+++ b/httpclient/socksify.go
@@ -24,14 +24,18 @@ func (f DialFunc) Dial(network, address string) (net.Conn, error) { return f(net
 
 func SOCKS5DialFuncFromEnvironment(origDialer DialFunc, socks5Proxy ProxyDialer) DialFunc {
 	allProxy := os.Getenv("BOSH_ALL_PROXY")
-	if len(allProxy) == 0 {
+	return NewSOCKS5DialFunc(allProxy, origDialer, socks5Proxy)
+}
+
+func NewSOCKS5DialFunc(proxyString string, origDialer DialFunc, socks5Proxy ProxyDialer) DialFunc {
+	if len(proxyString) == 0 {
 		return origDialer
 	}
 
-	if strings.HasPrefix(allProxy, "ssh+") {
-		allProxy = strings.TrimPrefix(allProxy, "ssh+")
+	if strings.HasPrefix(proxyString, "ssh+") {
+		proxyString = strings.TrimPrefix(proxyString, "ssh+")
 
-		proxyURL, err := url.Parse(allProxy)
+		proxyURL, err := url.Parse(proxyString)
 		if err != nil {
 			return origDialer
 		}
@@ -81,7 +85,7 @@ func SOCKS5DialFuncFromEnvironment(origDialer DialFunc, socks5Proxy ProxyDialer)
 		}
 	}
 
-	proxyURL, err := url.Parse(allProxy)
+	proxyURL, err := url.Parse(proxyString)
 	if err != nil {
 		return origDialer
 	}

--- a/httpclient/socksify_test.go
+++ b/httpclient/socksify_test.go
@@ -20,7 +20,6 @@ var _ = Describe("Socksify", func() {
 	var (
 		proxyDialer *FakeProxyDialer
 		origDial    DialFunc
-		dialFunc    DialFunc
 	)
 
 	BeforeEach(func() {
@@ -28,138 +27,169 @@ var _ = Describe("Socksify", func() {
 		origDial = DialFunc(func(x, y string) (net.Conn, error) {
 			return nil, errors.New("original dialer")
 		})
-		dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 	})
-	Context("When BOSH_ALL_PROXY is not set", func() {
-		It("Returns the dialer that was passed in", func() {
-			_, err := dialFunc("", "")
-			Expect(err).To(MatchError("original dialer"))
-			Expect(proxyDialer.DialerCall.CallCount).To(Equal(0))
+
+	Describe("#SOCKS5DialFuncFromEnvironment", func() {
+		It("Returns a function that creates a socks5 proxy dialer", func() {
+			proxyDialer.DialerCall.Returns.DialFunc = proxy.DialFunc(func(x, y string) (net.Conn, error) {
+				return nil, errors.New("proxy dialer")
+			})
+
+			privateKeyPath := writeKeyFile("some-key")
+			os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?private-key=%s", privateKeyPath))
+
+			_, err := SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)("", "")
+			Expect(err).To(MatchError("proxy dialer"))
+			Expect(proxyDialer.DialerCall.CallCount).To(Equal(1))
+			Expect(proxyDialer.DialerCall.Receives.Key).To(Equal("some-key"))
+			Expect(proxyDialer.DialerCall.Receives.URL).To(Equal("localhost:12345"))
 		})
 	})
 
-	Context("When BOSH_ALL_PROXY is set", func() {
-		Context("When BOSH_ALL_PROXY is prefixed with ssh+", func() {
-			BeforeEach(func() {
-				proxyDialer.DialerCall.Returns.DialFunc = proxy.DialFunc(func(x, y string) (net.Conn, error) {
-					return nil, errors.New("proxy dialer")
+	Describe("#NewSOCKS5DialFunc", func() {
+		var dialFunc DialFunc
+		BeforeEach(func() {
+			dialFunc = NewSOCKS5DialFunc("", origDial, proxyDialer)
+		})
+
+		Context("When the proxy variable is blank", func() {
+			It("Returns the dialer that was passed in", func() {
+				_, err := dialFunc("", "")
+				Expect(err).To(MatchError("original dialer"))
+				Expect(proxyDialer.DialerCall.CallCount).To(Equal(0))
+			})
+		})
+		Context("When the proxy is not blank", func() {
+			Context("When the proxy is prefixed with ssh+", func() {
+				BeforeEach(func() {
+					proxyDialer.DialerCall.Returns.DialFunc = proxy.DialFunc(func(x, y string) (net.Conn, error) {
+						return nil, errors.New("proxy dialer")
+					})
+
+					privateKeyPath := writeKeyFile("some-key")
+					proxy := fmt.Sprintf("ssh+socks5://localhost:12345?private-key=%s", privateKeyPath)
+
+					dialFunc = NewSOCKS5DialFunc(proxy, origDial, proxyDialer)
 				})
-				tempDir, err := ioutil.TempDir("", "")
-				Expect(err).NotTo(HaveOccurred())
-				privateKeyPath := filepath.Join(tempDir, "test.key")
-				err = ioutil.WriteFile(privateKeyPath, []byte("some-key"), 0600)
-				Expect(err).NotTo(HaveOccurred())
-				os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?private-key=%s", privateKeyPath))
 
-				dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
-			})
-
-			It("Returns a function that creates a socks5 proxy dialer", func() {
-				_, err := dialFunc("", "")
-				Expect(err).To(MatchError("proxy dialer"))
-				Expect(proxyDialer.DialerCall.CallCount).To(Equal(1))
-				Expect(proxyDialer.DialerCall.Receives.Key).To(Equal("some-key"))
-				Expect(proxyDialer.DialerCall.Receives.URL).To(Equal("localhost:12345"))
-			})
-
-			It("Can be called multiple times and only create the dialer once", func() {
-				_, err := dialFunc("", "")
-				Expect(err).To(MatchError("proxy dialer"))
-				_, err = dialFunc("", "")
-				Expect(err).To(MatchError("proxy dialer"))
-				Expect(proxyDialer.DialerCall.CallCount).To(Equal(1))
-				Expect(proxyDialer.DialerCall.Receives.Key).To(Equal("some-key"))
-				Expect(proxyDialer.DialerCall.Receives.URL).To(Equal("localhost:12345"))
-			})
-
-			It("Can be concurrently (run ginkgo with -race flag)", func() {
-				errs := make(chan error)
-				for i := 0; i < 20; i++ {
-					go func() {
-						_, err := dialFunc("", "")
-						errs <- err
-					}()
-				}
-				for i := 0; i < 20; i++ {
-					err := <-errs
+				It("Returns a function that creates a socks5 proxy dialer", func() {
+					_, err := dialFunc("", "")
 					Expect(err).To(MatchError("proxy dialer"))
-				}
-				Expect(proxyDialer.DialerCall.CallCount).To(Equal(1))
-				Expect(proxyDialer.DialerCall.Receives.Key).To(Equal("some-key"))
-				Expect(proxyDialer.DialerCall.Receives.URL).To(Equal("localhost:12345"))
+					Expect(proxyDialer.DialerCall.CallCount).To(Equal(1))
+					Expect(proxyDialer.DialerCall.Receives.Key).To(Equal("some-key"))
+					Expect(proxyDialer.DialerCall.Receives.URL).To(Equal("localhost:12345"))
+				})
+
+				It("Can be called multiple times and only create the dialer once", func() {
+					_, err := dialFunc("", "")
+					Expect(err).To(MatchError("proxy dialer"))
+					_, err = dialFunc("", "")
+					Expect(err).To(MatchError("proxy dialer"))
+					Expect(proxyDialer.DialerCall.CallCount).To(Equal(1))
+					Expect(proxyDialer.DialerCall.Receives.Key).To(Equal("some-key"))
+					Expect(proxyDialer.DialerCall.Receives.URL).To(Equal("localhost:12345"))
+				})
+
+				It("Can be concurrently (run ginkgo with -race flag)", func() {
+					errs := make(chan error)
+					for i := 0; i < 20; i++ {
+						go func() {
+							_, err := dialFunc("", "")
+							errs <- err
+						}()
+					}
+					for i := 0; i < 20; i++ {
+						err := <-errs
+						Expect(err).To(MatchError("proxy dialer"))
+					}
+					Expect(proxyDialer.DialerCall.CallCount).To(Equal(1))
+					Expect(proxyDialer.DialerCall.Receives.Key).To(Equal("some-key"))
+					Expect(proxyDialer.DialerCall.Receives.URL).To(Equal("localhost:12345"))
+				})
+
+				Context("when the URL after the ssh+ prefix cannot be parsed", func() {
+					BeforeEach(func() {
+						proxy := fmt.Sprintf("ssh+:cannot-start-with-colon")
+						dialFunc = NewSOCKS5DialFunc(proxy, origDial, proxyDialer)
+					})
+					It("returns the dialer that was passed in", func() {
+						_, err := dialFunc("", "")
+						Expect(err).To(MatchError("original dialer"))
+					})
+				})
+
+				Context("when the query params in the URL cannot be parsed", func() {
+					BeforeEach(func() {
+						proxy := fmt.Sprintf("ssh+socks5://localhost:12345?foo=%%")
+						dialFunc = NewSOCKS5DialFunc(proxy, origDial, proxyDialer)
+					})
+					It("returns the dialer that was passed in", func() {
+						_, err := dialFunc("", "")
+						Expect(err).To(MatchError("original dialer"))
+					})
+				})
+
+				Context("when the query params do not contain the private key path", func() {
+					BeforeEach(func() {
+						proxy := fmt.Sprintf("ssh+socks5://localhost:12345?foo=bar")
+						dialFunc = NewSOCKS5DialFunc(proxy, origDial, proxyDialer)
+					})
+					It("returns the dialer that was passed in", func() {
+						_, err := dialFunc("", "")
+						Expect(err).To(MatchError("original dialer"))
+					})
+				})
+
+				Context("when no key exists at the private key path", func() {
+					BeforeEach(func() {
+						proxy := fmt.Sprintf("ssh+socks5://localhost:12345?private-key=/no/file/here")
+						dialFunc = NewSOCKS5DialFunc(proxy, origDial, proxyDialer)
+					})
+					It("returns the dialer that was passed in", func() {
+						_, err := dialFunc("", "")
+						Expect(err).To(MatchError("original dialer"))
+					})
+				})
 			})
 
-			Context("when the URL after the ssh+ prefix cannot be parsed", func() {
-				BeforeEach(func() {
-					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+:cannot-start-with-colon"))
-					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
+			Context("When the proxy is *not* prefixed with ssh+", func() {
+				// Happy paths not tested
+				Context("when the URL cannot be parsed", func() {
+					BeforeEach(func() {
+						proxy := fmt.Sprintf(":cannot-start-with-colon")
+						dialFunc = NewSOCKS5DialFunc(proxy, origDial, proxyDialer)
+					})
+					It("returns the dialer that was passed in", func() {
+						_, err := dialFunc("", "")
+						Expect(err).To(MatchError("original dialer"))
+					})
 				})
-				It("returns the dialer that was passed in", func() {
-					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
-				})
-			})
 
-			Context("when the query params in the URL cannot be parsed", func() {
-				BeforeEach(func() {
-					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?foo=%%"))
-					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
-				})
-				It("returns the dialer that was passed in", func() {
-					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
-				})
-			})
-
-			Context("when the query params do not contain the private key path", func() {
-				BeforeEach(func() {
-					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?foo=bar"))
-					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
-				})
-				It("returns the dialer that was passed in", func() {
-					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
-				})
-			})
-
-			Context("when no key exists at the private key path", func() {
-				BeforeEach(func() {
-					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?private-key=/no/file/here"))
-					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
-				})
-				It("returns the dialer that was passed in", func() {
-					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
+				Context("when the URL is not a valid proxy scheme", func() {
+					BeforeEach(func() {
+						proxy := fmt.Sprintf("foo://cannot-start-with-colon")
+						dialFunc = NewSOCKS5DialFunc(proxy, origDial, proxyDialer)
+					})
+					It("returns the dialer that was passed in", func() {
+						_, err := dialFunc("", "")
+						Expect(err).To(MatchError("original dialer"))
+					})
 				})
 			})
 		})
 
-		Context("When BOSH_ALL_PROXY is *not* prefixed with ssh+", func() {
-			// Happy paths not tested
-			Context("when the URL cannot be parsed", func() {
-				BeforeEach(func() {
-					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf(":cannot-start-with-colon"))
-					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
-				})
-				It("returns the dialer that was passed in", func() {
-					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
-				})
-			})
-
-			Context("when the URL is not a valid proxy scheme", func() {
-				BeforeEach(func() {
-					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("foo://cannot-start-with-colon"))
-					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
-				})
-				It("returns the dialer that was passed in", func() {
-					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
-				})
-			})
-		})
 	})
 })
+
+func writeKeyFile(value string) string {
+	tempDir, err := ioutil.TempDir("", "")
+	Expect(err).NotTo(HaveOccurred())
+	privateKeyPath := filepath.Join(tempDir, "key")
+	err = ioutil.WriteFile(privateKeyPath, []byte(value), 0600)
+	Expect(err).NotTo(HaveOccurred())
+
+	return privateKeyPath
+}
 
 type FakeProxyDialer struct {
 	DialerCall struct {


### PR DESCRIPTION
The credhub team wants to make use of the dialer func, but our proxy string would be found in a different env var. We extracted the functionality of `SOCKS5DialFuncFromEnvironment` so it can be used more generically.

[#154639914] credhub CLI respects ssh+socks5 scheme configured in an env var