### PR TITLE
Stop using powershell for every command

### DIFF
--- a/system/cmd_runner_interface.go
+++ b/system/cmd_runner_interface.go
@@ -19,6 +19,9 @@ type Command struct {
 	// Don't echo stdout/stderr
 	Quiet bool
 
+	// If invoking a shell script (for platform-specific behaviors)
+	IsScript bool
+
 	Stdin io.Reader
 
 	// Full stdout and stderr will be captured to memory

--- a/system/exec_cmd_runner.go
+++ b/system/exec_cmd_runner.go
@@ -64,7 +64,7 @@ func (r execCmdRunner) CommandExists(cmdName string) bool {
 }
 
 func (r execCmdRunner) buildComplexCommand(cmd Command) *exec.Cmd {
-	execCmd := newExecCmd(cmd.Name, cmd.Args...)
+	execCmd := newExecCmd(cmd.IsScript, cmd.Name, cmd.Args...)
 
 	if cmd.Stdin != nil {
 		execCmd.Stdin = cmd.Stdin

--- a/system/exec_cmd_runner_test.go
+++ b/system/exec_cmd_runner_test.go
@@ -25,11 +25,11 @@ var windowsCommands = map[string]Command{
 	},
 	"stderr": Command{
 		Name: "powershell",
-		Args: []string{`"[Console]::Error.WriteLine('error-output')"`},
+		Args: []string{"[Console]::Error.WriteLine('error-output')"},
 	},
 	"exit": Command{
-		Name: fmt.Sprintf("exit %d", ErrExitCode),
-		Args: []string{},
+		Name: "powershell",
+		Args: []string{fmt.Sprintf("exit %d", ErrExitCode)},
 	},
 	"ls": Command{
 		Name:       "powershell",
@@ -380,11 +380,7 @@ var _ = Describe("execCmdRunner", func() {
 		It("run command with error with args", func() {
 			stdout, stderr, status, err := runner.RunCommand(FalseExePath, "second arg")
 			Expect(err).To(HaveOccurred())
-			errMsg := fmt.Sprintf("Running command: '%s second arg', stdout: '', stderr: '': exit status 1", FalseExePath)
-			if runtime.GOOS == "windows" {
-				errMsg = fmt.Sprintf("Running command: 'powershell %s second arg', stdout: '', stderr: '': exit status 1", FalseExePath)
-			}
-			Expect(err.Error()).To(Equal(errMsg))
+			Expect(err.Error()).To(Equal(fmt.Sprintf("Running command: '%s second arg', stdout: '', stderr: '': exit status 1", FalseExePath)))
 			Expect(stderr).To(BeEmpty())
 			Expect(stdout).To(BeEmpty())
 			Expect(status).To(Equal(1))

--- a/system/exec_cmd_runner_test.go
+++ b/system/exec_cmd_runner_test.go
@@ -235,6 +235,19 @@ var _ = Describe("execCmdRunner", func() {
 			Expect(envVars).To(HaveKeyWithValue("_BAR", "alpha=first"))
 		})
 
+		It("executes scripts", func() {
+			cmd := Command{
+				Name:     "test_assets/script",
+				IsScript: true,
+			}
+
+			stdout, stderr, status, err := runner.RunComplexCommand(cmd)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout).To(MatchRegexp(`^it works\r?\n$`))
+			Expect(stderr).To(BeEmpty())
+			Expect(status).To(Equal(0))
+		})
+
 		It("run complex command with stdin", func() {
 			input := "This is STDIN\nWith another line."
 			cmd := Command{

--- a/system/exec_cmd_runner_unix.go
+++ b/system/exec_cmd_runner_unix.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func newExecCmd(name string, args ...string) *exec.Cmd {
+func newExecCmd(isScript bool, name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
 }
 

--- a/system/exec_cmd_runner_windows.go
+++ b/system/exec_cmd_runner_windows.go
@@ -7,8 +7,7 @@ import (
 )
 
 func newExecCmd(name string, args ...string) *exec.Cmd {
-	args = append([]string{name}, args...)
-	return exec.Command(`powershell`, args...)
+	return exec.Command(name, args...)
 }
 
 // mergeEnv case-insensitive merge of system and command environments variables.

--- a/system/exec_cmd_runner_windows.go
+++ b/system/exec_cmd_runner_windows.go
@@ -1,12 +1,17 @@
 package system
 
 import (
+	"fmt"
 	"os/exec"
 	"sort"
 	"strings"
 )
 
-func newExecCmd(name string, args ...string) *exec.Cmd {
+func newExecCmd(isScript bool, name string, args ...string) *exec.Cmd {
+	if isScript {
+		return exec.Command("powershell", append([]string{fmt.Sprintf("%s.ps1", name)}, args...)...)
+	}
+
 	return exec.Command(name, args...)
 }
 

--- a/system/test_assets/script
+++ b/system/test_assets/script
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "it works"

--- a/system/test_assets/script.ps1
+++ b/system/test_assets/script.ps1
@@ -1,0 +1,1 @@
+echo "it works"


### PR DESCRIPTION
We were prefixing the execution of all commands on Windows with `powershell`. This results in [some](https://github.com/cloudfoundry/bosh-agent/blob/1a6b1e11acd941e65c4f4155c22ff9a8f76098f9/platform/cert/windows_cert_manager.go#L41) [things](https://github.com/cloudfoundry/bosh-agent/blob/ab1161a0360aa945ebe0d5db9f2c173caf4e02b9/platform/windows_platform.go#L295) running `powershell powershell -Command Get-ChildItem ...`, but it also has some side-effects when trying to do `bosh ssh -c "multiple; commands"` since the `;` starts execution of a new, local command. This fixes that.

We added a new `IsScript` bool to continue allowing consumers of this library to ignore OS differences and not be concerned with powershell or the `ps1` extensions. For example, we refactored some of [bosh-agent's code](https://github.com/cloudfoundry/bosh-agent/compare/develop...cmd-is-script) to avoid it having Windows-specific references.

/cc @cloudfoundry/cf-bosh-windows - does this change seem reasonable from a Windows perspective? We wanted to double check before we merge since this may impact you.