### PR TITLE
based on response to make some logical judgment

### DIFF
--- a/httpclient/http_client.go
+++ b/httpclient/http_client.go
@@ -129,7 +129,7 @@ func (c *HTTPClient) GetCustomized(endpoint string, f func(*http.Request)) (*htt
 
 	response, err := c.client.Do(request)
 	if err != nil {
-		return nil, bosherr.WrapError(scrubErrorOutput(err), "Performing GET request")
+		return response, bosherr.WrapError(scrubErrorOutput(err), "Performing GET request")
 	}
 
 	return response, nil

--- a/httpclient/http_client_test.go
+++ b/httpclient/http_client_test.go
@@ -540,6 +540,30 @@ var _ = Describe("HTTPClient", func() {
 			Expect(err.Error()).To(ContainSubstring("Get https://foo:<redacted>@10.10.0.0:8080/path"))
 		})
 
+		It("get 404 response from error message", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/path"),
+					ghttp.RespondWith(http.StatusNotFound, []byte("get-response")),
+				),
+			)
+
+			url := server.URL() + "/path"
+
+			response, err := httpClient.Get(url)
+			Expect(err).ToNot(HaveOccurred())
+
+			defer response.Body.Close()
+
+			responseBody, err := ioutil.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(responseBody).To(Equal([]byte("get-response")))
+			Expect(response.StatusCode).To(Equal(404))
+
+			Expect(server.ReceivedRequests()).To(HaveLen(1))
+		})
+
 		Describe("httpclient opts", func() {
 			var opts Opts
 


### PR DESCRIPTION
The PR returns a response when getting http request failed. And it aims to help some packages which dependence on bosh-utils make them more stronger by parsing response status code, body and other fields. For example, when deploying cloud foundry, if there is no setting ssh key, getting ssh key response will return a '404' response, and bosh agent can according to the response to make some fault tolerance, not throw error directly.