### PR TITLE
Remove duplicate prune directive

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,6 @@ required = ["github.com/onsi/ginkgo/ginkgo"]
   unused-packages = true
   go-tests = true
   non-go = true
-  go-tests = true
 
 [[constraint]]
   name = "github.com/bmatcuk/doublestar"


### PR DESCRIPTION
This prevents bumping the dependency using dep:
```
Solving failure: No versions of github.com/cloudfoundry/bosh-utils met constraints:
	master: manifest validation failed: unable to load TomlTree from string: (7, 3): The following key was defined twice: prune.go-tests
```