### PR TITLE
Return parsing errors for $BOSH_ALL_PROXY

### DIFF
--- a/httpclient/socksify.go
+++ b/httpclient/socksify.go
@@ -11,6 +11,7 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	proxy "github.com/cloudfoundry/socks5-proxy"
 
+	"errors"
 	goproxy "golang.org/x/net/proxy"
 )
 
@@ -33,12 +34,12 @@ func SOCKS5DialFuncFromEnvironment(origDialer DialFunc, socks5Proxy ProxyDialer)
 
 		proxyURL, err := url.Parse(allProxy)
 		if err != nil {
-			return origDialer
+			return errorDialFunc(err, "Parsing BOSH_ALL_PROXY url")
 		}
 
 		queryMap, err := url.ParseQuery(proxyURL.RawQuery)
 		if err != nil {
-			return origDialer
+			return errorDialFunc(err, "Parsing BOSH_ALL_PROXY query params")
 		}
 
 		username := ""
@@ -46,18 +47,17 @@ func SOCKS5DialFuncFromEnvironment(origDialer DialFunc, socks5Proxy ProxyDialer)
 			username = proxyURL.User.Username()
 		}
 
-		proxySSHKeyPath, ok := queryMap["private-key"]
-		if !ok {
-			return origDialer
+		proxySSHKeyPath := queryMap.Get("private-key")
+		if proxySSHKeyPath == "" {
+			return errorDialFunc(
+				errors.New("Required query param 'private-key' not found"),
+				"Parsing BOSH_ALL_PROXY query params",
+			)
 		}
 
-		if len(proxySSHKeyPath) == 0 {
-			return origDialer
-		}
-
-		proxySSHKey, err := ioutil.ReadFile(proxySSHKeyPath[0])
+		proxySSHKey, err := ioutil.ReadFile(proxySSHKeyPath)
 		if err != nil {
-			return origDialer
+			return errorDialFunc(err, "Reading private key file for SOCKS5 Proxy")
 		}
 
 		var (
@@ -88,12 +88,12 @@ func SOCKS5DialFuncFromEnvironment(origDialer DialFunc, socks5Proxy ProxyDialer)
 
 	proxyURL, err := url.Parse(allProxy)
 	if err != nil {
-		return origDialer
+		return errorDialFunc(err, "Parsing BOSH_ALL_PROXY url")
 	}
 
 	proxy, err := goproxy.FromURL(proxyURL, origDialer)
 	if err != nil {
-		return origDialer
+		return errorDialFunc(err, "Parsing BOSH_ALL_PROXY url")
 	}
 
 	noProxy := os.Getenv("no_proxy")
@@ -105,4 +105,10 @@ func SOCKS5DialFuncFromEnvironment(origDialer DialFunc, socks5Proxy ProxyDialer)
 	perHost.AddFromString(noProxy)
 
 	return perHost.Dial
+}
+
+func errorDialFunc(err error, cause string) DialFunc {
+	return func(network, address string) (net.Conn, error) {
+		return nil, bosherr.WrapError(err, cause)
+	}
 }

--- a/httpclient/socksify_test.go
+++ b/httpclient/socksify_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Socksify", func() {
 		})
 		dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 	})
+
 	Context("When BOSH_ALL_PROXY is not set", func() {
 		It("Returns the dialer that was passed in", func() {
 			_, err := dialFunc("", "")
@@ -119,9 +120,12 @@ var _ = Describe("Socksify", func() {
 					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+:cannot-start-with-colon"))
 					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 				})
-				It("returns the dialer that was passed in", func() {
+				It("returns a dialer that returns the url parsing error", func() {
 					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
+					Expect(err).To(MatchError(SatisfyAll(
+						ContainSubstring("Parsing BOSH_ALL_PROXY url"),
+						ContainSubstring(":cannot-start-with-colon"),
+					)))
 				})
 			})
 
@@ -130,9 +134,12 @@ var _ = Describe("Socksify", func() {
 					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?foo=%%"))
 					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 				})
-				It("returns the dialer that was passed in", func() {
+				It("returns a dialer that returns the query param parsing error", func() {
 					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
+					Expect(err).To(MatchError(SatisfyAll(
+						ContainSubstring("Parsing BOSH_ALL_PROXY query params"),
+						ContainSubstring("%"),
+					)))
 				})
 			})
 
@@ -141,9 +148,12 @@ var _ = Describe("Socksify", func() {
 					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?foo=bar"))
 					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 				})
-				It("returns the dialer that was passed in", func() {
+				It("returns a dialer that returns the param not found error", func() {
 					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
+					Expect(err).To(MatchError(SatisfyAll(
+						ContainSubstring("Parsing BOSH_ALL_PROXY query params"),
+						ContainSubstring("Required query param 'private-key' not found"),
+					)))
 				})
 			})
 
@@ -152,9 +162,12 @@ var _ = Describe("Socksify", func() {
 					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("ssh+socks5://localhost:12345?private-key=/no/file/here"))
 					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 				})
-				It("returns the dialer that was passed in", func() {
+				It("returns a dialer that returns the private key file not found error", func() {
 					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
+					Expect(err).To(MatchError(SatisfyAll(
+						ContainSubstring("Reading private key file for SOCKS5 Proxy"),
+						ContainSubstring("/no/file/here"),
+					)))
 				})
 			})
 		})
@@ -166,9 +179,12 @@ var _ = Describe("Socksify", func() {
 					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf(":cannot-start-with-colon"))
 					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 				})
-				It("returns the dialer that was passed in", func() {
+				It("returns a dialer that returns the parsing error", func() {
 					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
+					Expect(err).To(MatchError(SatisfyAll(
+						ContainSubstring("Parsing BOSH_ALL_PROXY url"),
+						ContainSubstring(":cannot-start-with-colon"),
+					)))
 				})
 			})
 
@@ -177,9 +193,12 @@ var _ = Describe("Socksify", func() {
 					os.Setenv("BOSH_ALL_PROXY", fmt.Sprintf("foo://cannot-start-with-colon"))
 					dialFunc = SOCKS5DialFuncFromEnvironment(origDial, proxyDialer)
 				})
-				It("returns the dialer that was passed in", func() {
+				It("returns a dialer returns the invalid proxy scheme error", func() {
 					_, err := dialFunc("", "")
-					Expect(err).To(MatchError("original dialer"))
+					Expect(err).To(MatchError(SatisfyAll(
+						ContainSubstring("Parsing BOSH_ALL_PROXY url"),
+						ContainSubstring("foo"),
+					)))
 				})
 			})
 		})


### PR DESCRIPTION
This changes the behaviour of `httpclient.SOCKS5DialFuncFromEnvironment` to return `DialFunc`s that return the errors that arise when parsing `$BOSH_ALL_PROXY`. Surfacing these errors will enable users to identify when the environment variable is misconfigured, or private key file is missing. For example: https://github.com/cloudfoundry/bosh-cli/issues/432.

Returning `DialFunc`s that return the parsing errors avoids a breaking change to the method signature to return `(DialFunc, error)`. This defers the parsing errors until `DialFunc` is called.

Resolves https://github.com/cloudfoundry/bosh-utils/issues/44.