### PR TITLE
Bump to latest socks5-proxy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,7 +32,7 @@
   branch = "master"
   name = "github.com/cloudfoundry/socks5-proxy"
   packages = ["."]
-  revision = "3c6b4eec9c2d16c1dac4c42bdb5f755ba09daff8"
+  revision = "3659db090cb23a57807b53e2f8580b2427dc2659"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -192,6 +192,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9da7fa4f4a6905e45e69a218ab88dacdfbcdbdec6310d0bf4e2781bb9a3a5885"
+  inputs-digest = "3a94ee7d808580ffcb21cf326cc0c41012a534179c4b8003661aa0c985ce0a43"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,3 +40,7 @@ required = ["github.com/onsi/ginkgo/ginkgo"]
 [[constraint]]
   branch = "master"
   name = "golang.org/x/net"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/cloudfoundry/socks5-proxy"

--- a/vendor/github.com/cloudfoundry/socks5-proxy/host_key.go
+++ b/vendor/github.com/cloudfoundry/socks5-proxy/host_key.go
@@ -28,13 +28,7 @@ func (h HostKey) Get(username, privateKey, serverURL string) (ssh.PublicKey, err
 		return nil, err
 	}
 
-	clientConfig := &ssh.ClientConfig{
-		User: username,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
-		HostKeyCallback: h.keyScanCallback,
-	}
+	clientConfig := NewSSHClientConfig(username, h.keyScanCallback, ssh.PublicKeys(signer))
 
 	go func() {
 		conn, err := ssh.Dial("tcp", serverURL, clientConfig)

--- a/vendor/github.com/cloudfoundry/socks5-proxy/socks5_proxy.go
+++ b/vendor/github.com/cloudfoundry/socks5-proxy/socks5_proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 
 	socks5 "github.com/cloudfoundry/go-socks5"
 
@@ -27,6 +28,7 @@ type Socks5Proxy struct {
 	port    int
 	started bool
 	logger  *log.Logger
+	mtx     sync.Mutex
 }
 
 func NewSocks5Proxy(hostKey hostKey, logger *log.Logger) *Socks5Proxy {
@@ -38,7 +40,7 @@ func NewSocks5Proxy(hostKey hostKey, logger *log.Logger) *Socks5Proxy {
 }
 
 func (s *Socks5Proxy) Start(username, key, url string) error {
-	if s.started {
+	if s.isStarted() {
 		return nil
 	}
 
@@ -53,6 +55,13 @@ func (s *Socks5Proxy) Start(username, key, url string) error {
 	}
 
 	return nil
+}
+
+// thread safety
+func (s *Socks5Proxy) isStarted() bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.started
 }
 
 func (s *Socks5Proxy) Dialer(username, key, url string) (DialFunc, error) {
@@ -70,13 +79,7 @@ func (s *Socks5Proxy) Dialer(username, key, url string) (DialFunc, error) {
 		return nil, fmt.Errorf("get host key: %s", err)
 	}
 
-	clientConfig := &ssh.ClientConfig{
-		User: username,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
-		HostKeyCallback: ssh.FixedHostKey(hostKey),
-	}
+	clientConfig := NewSSHClientConfig(username, ssh.FixedHostKey(hostKey), ssh.PublicKeys(signer))
 
 	conn, err := ssh.Dial("tcp", url, clientConfig)
 	if err != nil {
@@ -99,6 +102,8 @@ func (s *Socks5Proxy) StartWithDialer(dialer DialFunc) error {
 		return fmt.Errorf("new socks5 server: %s", err) // not tested
 	}
 
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	if s.port == 0 {
 		s.port, err = openPort()
 		if err != nil {
@@ -115,6 +120,8 @@ func (s *Socks5Proxy) StartWithDialer(dialer DialFunc) error {
 }
 
 func (s *Socks5Proxy) Addr() (string, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	if s.port == 0 {
 		return "", errors.New("socks5 proxy is not running")
 	}

--- a/vendor/github.com/cloudfoundry/socks5-proxy/ssh_client_config.go
+++ b/vendor/github.com/cloudfoundry/socks5-proxy/ssh_client_config.go
@@ -1,0 +1,15 @@
+package proxy
+
+import (
+	"golang.org/x/crypto/ssh"
+	"time"
+)
+
+func NewSSHClientConfig(user string, hostKeyCallback ssh.HostKeyCallback, authMethods ...ssh.AuthMethod) *ssh.ClientConfig {
+	return &ssh.ClientConfig{
+		Timeout:         30 * time.Second,
+		User:            user,
+		HostKeyCallback: hostKeyCallback,
+		Auth:            authMethods,
+	}
+}


### PR DESCRIPTION
Includes two fixes in socks5-proxy:
- Set a 30s timeout in ssh client config: https://github.com/cloudfoundry/socks5-proxy/pull/11
- fix data race on Socks5Proxy.port: https://github.com/cloudfoundry/socks5-proxy/commit/75791c35e37dfa939d956361aaf9569e66c0e318