### PR TITLE
Store BlobManager temporary files in the same directory as the blobs

### DIFF
--- a/blobstore/blob_manager.go
+++ b/blobstore/blob_manager.go
@@ -15,14 +15,14 @@ import (
 )
 
 type BlobManager struct {
-	fs            boshsys.FileSystem
-	blobstorePath string
+	fs      boshsys.FileSystem
+	workdir string
 }
 
-func NewBlobManager(fs boshsys.FileSystem, blobstorePath string) BlobManager {
+func NewBlobManager(fs boshsys.FileSystem, workdir string) BlobManager {
 	return BlobManager{
-		fs:            fs,
-		blobstorePath: blobstorePath,
+		fs:      fs,
+		workdir: workdir,
 	}
 }
 
@@ -140,11 +140,11 @@ func (m BlobManager) createDirStructure() error {
 }
 
 func (m BlobManager) blobsPath() string {
-	return path.Join(m.blobstorePath, "blobs")
+	return path.Join(m.workdir, "blobs")
 }
 
 func (m BlobManager) tmpPath() string {
-	return path.Join(m.blobstorePath, "tmp")
+	return path.Join(m.workdir, "tmp")
 }
 
 func (m BlobManager) blobPath(id string) string {

--- a/blobstore/blob_manager.go
+++ b/blobstore/blob_manager.go
@@ -18,10 +18,11 @@ type BlobManager struct {
 	blobstorePath string
 }
 
-func NewBlobManager(fs boshsys.FileSystem, blobstorePath string) (manager BlobManager) {
-	manager.fs = fs
-	manager.blobstorePath = blobstorePath
-	return
+func NewBlobManager(fs boshsys.FileSystem, blobstorePath string) BlobManager {
+	return BlobManager{
+		fs:            fs,
+		blobstorePath: blobstorePath,
+	}
 }
 
 func (manager BlobManager) Fetch(blobID string) (boshsys.File, error, int) {

--- a/blobstore/blob_manager.go
+++ b/blobstore/blob_manager.go
@@ -32,11 +32,7 @@ func (m BlobManager) Fetch(blobID string) (boshsys.File, error, int) {
 	blobPath := m.blobPath(blobID)
 	file, err := os.Open(blobPath)
 	if err != nil {
-		status := 500
-		if strings.Contains(err.Error(), "no such file") {
-			status = 404
-		}
-		return nil, bosherr.WrapError(err, "Reading blob"), status
+		return nil, bosherr.WrapError(err, "Reading blob"), statusForErr(err)
 	}
 
 	return file, nil, 200
@@ -151,6 +147,18 @@ func (m BlobManager) tmpPath() string {
 
 func (m BlobManager) blobPath(id string) string {
 	return path.Join(m.blobsPath(), id)
+}
+
+func statusForErr(err error) int {
+	if err == nil {
+		return 200
+	}
+
+	if strings.Contains(err.Error(), "no such file") {
+		return 404
+	}
+
+	return 500
 }
 
 func mkdir(path string) error {

--- a/blobstore/blob_manager_test.go
+++ b/blobstore/blob_manager_test.go
@@ -39,16 +39,22 @@ var _ = Describe("Blob Manager", func() {
 		os.RemoveAll(basePath)
 	})
 
+	getBlob := func(id string) string {
+		file, err, status := blobManager.Fetch(id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(200))
+
+		contents, err := fs.ReadFileString(file.Name())
+		Expect(err).ToNot(HaveOccurred())
+
+		return contents
+	}
+
 	It("can fetch what was written", func() {
 		err := blobManager.Write(blobID, strings.NewReader("new data"))
 		Expect(err).ToNot(HaveOccurred())
 
-		readOnlyFile, err, status := blobManager.Fetch(blobID)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(status).To(Equal(200))
-
-		contents, err := fs.ReadFileString(readOnlyFile.Name())
-		Expect(err).ToNot(HaveOccurred())
+		contents := getBlob(blobID)
 		Expect(contents).To(Equal("new data"))
 	})
 
@@ -59,12 +65,7 @@ var _ = Describe("Blob Manager", func() {
 		err = blobManager.Write(blobID, strings.NewReader("new data"))
 		Expect(err).ToNot(HaveOccurred())
 
-		readOnlyFile, err, status := blobManager.Fetch(blobID)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(status).To(Equal(200))
-
-		contents, err := fs.ReadFileString(readOnlyFile.Name())
-		Expect(err).ToNot(HaveOccurred())
+		contents := getBlob(blobID)
 		Expect(contents).To(Equal("new data"))
 	})
 
@@ -72,24 +73,14 @@ var _ = Describe("Blob Manager", func() {
 		err := blobManager.Write(blobID, strings.NewReader("data1"))
 		Expect(err).ToNot(HaveOccurred())
 
-		otherBlobId := "other-blob-id"
-		err = blobManager.Write(otherBlobId, strings.NewReader("data2"))
+		otherBlobID := "other-blob-id"
+		err = blobManager.Write(otherBlobID, strings.NewReader("data2"))
 		Expect(err).ToNot(HaveOccurred())
 
-		readOnlyFile, err, status := blobManager.Fetch(blobID)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(status).To(Equal(200))
-
-		contents, err := fs.ReadFileString(readOnlyFile.Name())
-		Expect(err).ToNot(HaveOccurred())
+		contents := getBlob(blobID)
 		Expect(contents).To(Equal("data1"))
 
-		otherFile, err, status := blobManager.Fetch(otherBlobId)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(status).To(Equal(200))
-
-		otherContents, err := fs.ReadFileString(otherFile.Name())
-		Expect(err).ToNot(HaveOccurred())
+		otherContents := getBlob(otherBlobID)
 		Expect(otherContents).To(Equal("data2"))
 	})
 
@@ -135,12 +126,7 @@ var _ = Describe("Blob Manager", func() {
 				err = fs.WriteFileString(path, "overwriting!")
 				Expect(err).NotTo(HaveOccurred())
 
-				readOnlyFile, err, status := blobManager.Fetch(blobID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(status).To(Equal(200))
-
-				contents, err := fs.ReadFileString(readOnlyFile.Name())
-				Expect(err).ToNot(HaveOccurred())
+				contents := getBlob(blobID)
 				Expect(contents).To(Equal("data"))
 			})
 

--- a/blobstore/blob_manager_test.go
+++ b/blobstore/blob_manager_test.go
@@ -1,214 +1,205 @@
 package blobstore_test
 
 import (
-	"bytes"
-	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
+	"strings"
 
-	. "github.com/cloudfoundry/bosh-utils/blobstore"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	boshsysfake "github.com/cloudfoundry/bosh-utils/system/fakes"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-utils/blobstore"
 )
 
 var _ = Describe("Blob Manager", func() {
 	var (
 		fs       boshsys.FileSystem
-		logger   boshlog.Logger
 		basePath string
-		blobPath string
-		blobId   string
-		toWrite  io.Reader
+
+		blobManager BlobManager
 	)
+
+	blobID := "105d33ae-655c-493d-bf9f-1df5cf3ca847"
 
 	BeforeEach(func() {
 		var err error
-		logger = boshlog.NewLogger(boshlog.LevelNone)
+		logger := boshlog.NewLogger(boshlog.LevelNone)
 		fs = boshsys.NewOsFileSystem(logger)
-		blobId = "105d33ae-655c-493d-bf9f-1df5cf3ca847"
-		basePath, err = ioutil.TempDir("", "blobstore")
+		basePath, err = ioutil.TempDir("", "blobmanager")
 		Expect(err).NotTo(HaveOccurred())
-		blobPath = filepath.Join(basePath, blobId)
-		toWrite = bytes.NewReader([]byte("new data"))
+
+		blobManager = NewBlobManager(fs, basePath)
 	})
 
-	readFile := func(fileIO boshsys.File) []byte {
-		fileStat, _ := fileIO.Stat()
-		fileBytes := make([]byte, fileStat.Size())
-		fileIO.Read(fileBytes)
-		return fileBytes
-	}
-
-	It("fetches", func() {
-		blobManager := NewBlobManager(fs, basePath)
-		fs.WriteFileString(blobPath, "some data")
-
-		readOnlyFile, err, _ := blobManager.Fetch(blobId)
-		Expect(err).NotTo(HaveOccurred())
-		defer fs.RemoveAll(readOnlyFile.Name())
-
-		Expect(err).ToNot(HaveOccurred())
-		fileBytes := readFile(readOnlyFile)
-
-		Expect(string(fileBytes)).To(Equal("some data"))
+	AfterEach(func() {
+		os.RemoveAll(basePath)
 	})
 
-	It("writes", func() {
-		blobManager := NewBlobManager(fs, basePath)
-		fs.WriteFileString(blobPath, "some data")
-		defer fs.RemoveAll(blobPath)
-
-		err := blobManager.Write(blobId, toWrite)
+	It("can fetch what was written", func() {
+		err := blobManager.Write(blobID, strings.NewReader("new data"))
 		Expect(err).ToNot(HaveOccurred())
 
-		contents, err := fs.ReadFileString(blobPath)
+		readOnlyFile, err, status := blobManager.Fetch(blobID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(200))
+
+		contents, err := fs.ReadFileString(readOnlyFile.Name())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(contents).To(Equal("new data"))
 	})
 
-	Context("when it writes", func() {
-		BeforeEach(func() {
-			basePath = filepath.ToSlash(basePath)
-			blobPath = filepath.ToSlash(blobPath)
-		})
+	It("can overwrite files", func() {
+		err := blobManager.Write(blobID, strings.NewReader("old data"))
+		Expect(err).ToNot(HaveOccurred())
 
-		It("creates and closes the file", func() {
-			fs_ := boshsysfake.NewFakeFileSystem()
-			blobManager := NewBlobManager(fs_, basePath)
-			err := blobManager.Write(blobId, toWrite)
-			Expect(err).ToNot(HaveOccurred())
-			fileStats, err := fs_.FindFileStats(blobPath)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fileStats.Open).To(BeFalse())
-		})
+		err = blobManager.Write(blobID, strings.NewReader("new data"))
+		Expect(err).ToNot(HaveOccurred())
 
-		It("creates file with correct permissions", func() {
-			fs_ := boshsysfake.NewFakeFileSystem()
-			blobManager := NewBlobManager(fs_, basePath)
-			err := blobManager.Write(blobId, toWrite)
-			fileStats, err := fs_.FindFileStats(blobPath)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fileStats.FileMode).To(Equal(os.FileMode(0600)))
-			Expect(fileStats.Flags).To(Equal(os.O_WRONLY | os.O_CREATE | os.O_TRUNC))
-		})
+		readOnlyFile, err, status := blobManager.Fetch(blobID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(200))
+
+		contents, err := fs.ReadFileString(readOnlyFile.Name())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(contents).To(Equal("new data"))
+	})
+
+	It("can store multiple files", func() {
+		err := blobManager.Write(blobID, strings.NewReader("data1"))
+		Expect(err).ToNot(HaveOccurred())
+
+		otherBlobId := "other-blob-id"
+		err = blobManager.Write(otherBlobId, strings.NewReader("data2"))
+		Expect(err).ToNot(HaveOccurred())
+
+		readOnlyFile, err, status := blobManager.Fetch(blobID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(200))
+
+		contents, err := fs.ReadFileString(readOnlyFile.Name())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(contents).To(Equal("data1"))
+
+		otherFile, err, status := blobManager.Fetch(otherBlobId)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(200))
+
+		otherContents, err := fs.ReadFileString(otherFile.Name())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(otherContents).To(Equal("data2"))
 	})
 
 	Describe("GetPath", func() {
 		var sampleDigest boshcrypto.Digest
 
 		BeforeEach(func() {
-			blobId = "smurf-24"
-			correctCheckSum := "f2b1b7be7897082d082773a1d1db5a01e8d21f5c"
+			correctCheckSum := "a17c9aaa61e80a1bf71d0d850af4e5baa9800bbd" // sha-1 of "data"
 			sampleDigest = boshcrypto.NewDigest(boshcrypto.DigestAlgorithmSHA1, correctCheckSum)
 		})
 
-		Context("when file requested does not exist in blobsPath", func() {
-			It("returns an error", func() {
-				blobManager := NewBlobManager(fs, basePath)
-
-				_, err := blobManager.GetPath("blob-id-does-not-exist", sampleDigest)
-
-				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal("Blob 'blob-id-does-not-exist' not found"))
-			})
-		})
-
 		Context("when file requested exists in blobsPath", func() {
+			BeforeEach(func() {
+				err := blobManager.Write(blobID, strings.NewReader("data"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			Context("when file checksum matches provided checksum", func() {
 				It("should return the path of a copy of the requested blob", func() {
-					blobManager := NewBlobManager(fs, basePath)
+					filename, err := blobManager.GetPath(blobID, sampleDigest)
+					Expect(err).NotTo(HaveOccurred())
 
-					err := fs.WriteFileString(filepath.Join(basePath, blobId), "smurf-content-hello")
-					defer fs.RemoveAll(blobPath)
-
-					Expect(err).To(BeNil())
-
-					filename, err := blobManager.GetPath(blobId, sampleDigest)
-					Expect(err).To(BeNil())
-					Expect(fs.ReadFileString(filename)).To(Equal("smurf-content-hello"))
-					Expect(filename).ToNot(Equal(filepath.Join(blobPath, blobId)))
+					contents, err := fs.ReadFileString(filename)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(contents).To(Equal("data"))
 				})
 			})
 
 			Context("when file checksum does NOT match provided checksum", func() {
 				It("should return an error", func() {
-					blobManager := NewBlobManager(fs, basePath)
-
-					err := fs.WriteFileString(filepath.Join(basePath, blobId), "smurf-content-hello-some-other")
-					defer fs.RemoveAll(blobPath)
-
-					Expect(err).To(BeNil())
-
-					filename, err := blobManager.GetPath(blobId, sampleDigest)
-
-					Expect(err).ToNot(BeNil())
-					Expect(err.Error()).To(Equal(`Checking blob 'smurf-24': Expected stream to have digest 'f2b1b7be7897082d082773a1d1db5a01e8d21f5c' but was '6edae0462d26d51e3351fffc9a5725560cc3dde6'`))
-
-					Expect(filename).To(Equal(""))
+					bogusDigest := boshcrypto.NewDigest(boshcrypto.DigestAlgorithmSHA1, "bogus-sha")
+					_, err := blobManager.GetPath(blobID, bogusDigest)
+					Expect(err).To(MatchError(ContainSubstring(blobID)))
+					Expect(err).To(MatchError(ContainSubstring(sampleDigest.String())))
+					Expect(err).To(MatchError(ContainSubstring(bogusDigest.String())))
 				})
+			})
+
+			It("does not allow modifications made to the returned path to affect the original file", func() {
+				path, err := blobManager.GetPath(blobID, sampleDigest)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = fs.WriteFileString(path, "overwriting!")
+				Expect(err).NotTo(HaveOccurred())
+
+				readOnlyFile, err, status := blobManager.Fetch(blobID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(200))
+
+				contents, err := fs.ReadFileString(readOnlyFile.Name())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(contents).To(Equal("data"))
+			})
+		})
+
+		Context("when file requested does not exist in blobsPath", func() {
+			It("returns an error", func() {
+				_, err := blobManager.GetPath("missing", sampleDigest)
+				Expect(err).To(MatchError("Blob 'missing' not found"))
 			})
 		})
 	})
 
 	Describe("Delete", func() {
-		BeforeEach(func() {
-			blobId = "smurf-25"
-		})
+		Context("when file to be deleted exists in blobsPath", func() {
+			BeforeEach(func() {
+				err := blobManager.Write(blobID, strings.NewReader("data"))
+				Expect(err).ToNot(HaveOccurred())
+			})
 
-		Context("when file to be deleted does not exist in blobsPath", func() {
-			It("does not freak out", func() {
-				blobManager := NewBlobManager(fs, basePath)
+			It("should delete the blob", func() {
+				exists := blobManager.BlobExists(blobID)
+				Expect(exists).To(BeTrue())
 
-				err := blobManager.Delete("hello-i-am-no-one")
+				err := blobManager.Delete(blobID)
+				Expect(err).NotTo(HaveOccurred())
 
-				Expect(err).To(BeNil())
+				exists = blobManager.BlobExists(blobID)
+				Expect(exists).To(BeFalse())
+
+				_, err, status := blobManager.Fetch(blobID)
+				Expect(err).To(HaveOccurred())
+				Expect(status).To(Equal(404))
 			})
 		})
 
-		Context("when file to be deleted exists in blobsPath", func() {
-			It("should delete the blob", func() {
-				err := fs.WriteFileString(filepath.Join(basePath, blobId), "smurf-content")
-				Expect(err).To(BeNil())
-				Expect(fs.FileExists(filepath.Join(basePath, blobId))).To(BeTrue())
-
-				blobManager := NewBlobManager(fs, basePath)
-				err = blobManager.Delete(blobId)
-				Expect(err).To(BeNil())
-
-				Expect(fs.FileExists(filepath.Join(basePath, blobId))).To(BeFalse())
+		Context("when file to be deleted does not exist in blobsPath", func() {
+			It("does not error", func() {
+				err := blobManager.Delete("hello-i-am-no-one")
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})
 
 	Describe("BlobExists", func() {
-		BeforeEach(func() {
-			blobId = "super-smurf"
-		})
-
 		Context("when blob requested exists in blobsPath", func() {
-			It("returns true", func() {
-				blobManager := NewBlobManager(fs, basePath)
-
-				err := fs.WriteFileString(filepath.Join(basePath, blobId), "super-smurf-content")
-				defer fs.RemoveAll(blobPath)
-
+			BeforeEach(func() {
+				err := blobManager.Write(blobID, strings.NewReader("super-smurf-content"))
 				Expect(err).To(BeNil())
+			})
 
-				exists := blobManager.BlobExists(blobId)
+			It("returns true", func() {
+				exists := blobManager.BlobExists(blobID)
 				Expect(exists).To(BeTrue())
 			})
 		})
 
 		Context("when blob requested does NOT exist in blobsPath", func() {
 			It("returns false", func() {
-				blobManager := NewBlobManager(fs, basePath)
 				exists := blobManager.BlobExists("blob-id-does-not-exist")
-
 				Expect(exists).To(BeFalse())
 			})
 		})

--- a/blobstore/blob_manager_test.go
+++ b/blobstore/blob_manager_test.go
@@ -143,6 +143,13 @@ var _ = Describe("Blob Manager", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(contents).To(Equal("data"))
 			})
+
+			It("puts the temporary file inside the work directory to make sure that no files leak out if it's mounted on a tmpfs", func() {
+				path, err := blobManager.GetPath(blobID, sampleDigest)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(path).To(HavePrefix(basePath))
+			})
 		})
 
 		Context("when file requested does not exist in blobsPath", func() {

--- a/blobstore/blob_manager_test.go
+++ b/blobstore/blob_manager_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Blob Manager", func() {
 		blobManager BlobManager
 	)
 
-	blobID := "105d33ae-655c-493d-bf9f-1df5cf3ca847"
+	blobID := "blob-id"
 
 	BeforeEach(func() {
 		var err error


### PR DESCRIPTION
In order to make sure that all job credentials never touch disk we need to account for each location that they're copied or moved between the job's rendered templates being downloaded and the job starting. The `BlobManager` is used by the agent when NATS template delivery is enabled. Our goal is to mount the `BlobManager` backing directory on `tmpfs` when the job directory tmpfs feature flag is enabled.

When other parts of the agent call `GetPath` at the moment the rendered templates are copied into a temporary directory which we can't guarantee is mounted on `tmpfs`. This change modifies the `BlobManager` to keep these temporary paths in the same directory as the blobs which will make it easier to account for the locations of rendered templates.

Blobs have been moved to a sub-directory of the given directory to make sure that temporary files are not mistaken for blobs under a different name. This change should be safe as this code is only used in the agent and a new agent means that the blobs directory will be empty. No migration of existing blobs needs to be performed.

I'm submitting this change for review because I soloed on it. **Please do not merge it!** I want to squash it and give it a good commit message rather than the many commits shown here. I've left the commits the way they were developed for ease of review. The unit tests pass after each commit and each commit only changes either the tests or the implementation (except the commit which added the actual feature mentioned above).

I refactored the tests not to mess around with private filesystem state so that I could make the directory change without any of them breaking.

@jfmyers9 and I agreed that moving away from the global `system.Filesystem` interface was fine. I tried to use the fake filesystem to test this but because the `TempFile` functions do not allow a parent directory to be specified they would need pretty extensive modifications in order to allow this to work. The fake setup in the `FakeFilesystem` around temporary files and directories is also pretty difficult to use and led to a lot of un-intuitive and fragile test setup.

The `Filesystem` argument is no longer used but I didn't want to change the public interface until this was given a :+1:. I was also wondering if this file should be moved to the BOSH agent codebase since it is only ever used there and is pretty tightly coupled to the NATS delivery of job templates feature. What do you think?