### PR TITLE
Fix functions that read symlinks to handle absolute paths correctly on Windows.

### DIFF
--- a/system/fakes/fake_file_system.go
+++ b/system/fakes/fake_file_system.go
@@ -677,6 +677,22 @@ func (fs *FakeFileSystem) Symlink(oldPath, newPath string) (err error) {
 }
 
 func (fs *FakeFileSystem) ReadAndFollowLink(symlinkPath string) (string, error) {
+	targetPath, err := fs.readAndFollowLink(symlinkPath)
+	if err != nil {
+		return targetPath, err
+	}
+
+	//Converts internal path formatting (which is UNIX/Linux based) to native OS file system path
+	//This emulates the real behavior of how the real file system returns symlink
+	if strings.HasPrefix(targetPath, "/"){
+		absFilePath, err := filepath.Abs(targetPath)
+		return absFilePath, err
+	}
+
+	return targetPath, err
+}
+
+func (fs *FakeFileSystem) readAndFollowLink(symlinkPath string) (string, error) {
 	if fs.ReadAndFollowLinkError != nil {
 		return "", fs.ReadAndFollowLinkError
 	}
@@ -703,7 +719,7 @@ func (fs *FakeFileSystem) ReadAndFollowLink(symlinkPath string) (string, error) 
 	}
 
 	if stat.FileType != FakeFileTypeSymlink {
-		dirPath, err := fs.ReadAndFollowLink(filepath.Dir(symlinkPath))
+		dirPath, err := fs.readAndFollowLink(filepath.Dir(symlinkPath))
 		if err != nil {
 			return "", err
 		}
@@ -712,15 +728,15 @@ func (fs *FakeFileSystem) ReadAndFollowLink(symlinkPath string) (string, error) 
 	}
 
 	if gopath.IsAbs(stat.SymlinkTarget) {
-		return fs.ReadAndFollowLink(stat.SymlinkTarget)
+		return fs.readAndFollowLink(stat.SymlinkTarget)
 	}
 
-	dirPath, err := fs.ReadAndFollowLink(filepath.Dir(symlinkPath))
+	dirPath, err := fs.readAndFollowLink(filepath.Dir(symlinkPath))
 	if err != nil {
 		return "", err
 	}
 
-	return fs.ReadAndFollowLink(gopath.Join(dirPath, stat.SymlinkTarget))
+	return fs.readAndFollowLink(gopath.Join(dirPath, stat.SymlinkTarget))
 }
 
 func (fs *FakeFileSystem) CopyFile(srcPath, dstPath string) error {

--- a/system/fakes/fake_file_system.go
+++ b/system/fakes/fake_file_system.go
@@ -402,8 +402,23 @@ func (fs *FakeFileSystem) StatHelper(path string) (os.FileInfo, error) {
 
 	return NewFakeFile(path, fs).Stat()
 }
+func (fs *FakeFileSystem) Readlink(symlinkPath string) (string, error) {
+	targetPath, err := fs.readlink(symlinkPath)
+	if err != nil {
+		return targetPath, err
+	}
 
-func (fs *FakeFileSystem) Readlink(path string) (string, error) {
+	//Converts internal path formatting (which is UNIX/Linux based) to native OS file system path
+	//This emulates the real behavior of how the real file system returns symlink
+	if strings.HasPrefix(targetPath, "/") {
+		absFilePath, err := filepath.Abs(targetPath)
+		return absFilePath, err
+	}
+
+	return targetPath, err
+}
+
+func (fs *FakeFileSystem) readlink(path string) (string, error) {
 	if fs.ReadlinkError != nil {
 		return "", fs.ReadlinkError
 	}

--- a/system/fakes/fake_file_system_test.go
+++ b/system/fakes/fake_file_system_test.go
@@ -463,6 +463,21 @@ var _ = Describe("FakeFileSystem", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(targetPath).To(Equal("foobarTarget"))
 			})
+			Context ("using absolute directory paths", func() {
+				It("returns the absolute path of target", func() {
+					err := fs.WriteFileString("/tmp/foobarbaz", "asdfghjk")
+					Expect(err).ToNot(HaveOccurred())
+					err = fs.Symlink("/tmp/foobarbaz", "/tmp/foobar")
+					Expect(err).ToNot(HaveOccurred())
+
+					targetPath, err := fs.Readlink("/tmp/foobar")
+					Expect(err).ToNot(HaveOccurred())
+					absFilepath, err := filepath.Abs("/tmp/foobarbaz")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(targetPath).To(Equal(absFilepath))
+
+				})
+			})
 		})
 
 		Context("when there is an error", func() {

--- a/system/fakes/fake_file_system_test.go
+++ b/system/fakes/fake_file_system_test.go
@@ -356,6 +356,22 @@ var _ = Describe("FakeFileSystem", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(targetPath).To(Equal("foobarbaz"))
 			})
+
+			Context ("using absolute directory paths", func() {
+				It("returns the absolute path of target", func() {
+					err := fs.WriteFileString("/tmp/foobarbaz", "asdfghjk")
+					Expect(err).ToNot(HaveOccurred())
+					err = fs.Symlink("/tmp/foobarbaz", "/tmp/foobar")
+					Expect(err).ToNot(HaveOccurred())
+
+					targetPath, err := fs.ReadAndFollowLink("/tmp/foobar")
+					Expect(err).ToNot(HaveOccurred())
+					absFilepath, err := filepath.Abs("/tmp/foobarbaz")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(targetPath).To(Equal(absFilepath))
+
+				})
+			})
 		})
 
 		Context("when the target is located in a parent directory", func() {


### PR DESCRIPTION
Prior to this change, there was discrepancy between fetching symlink target file paths between the fake implementation and real implementation on Windows. The fake implementation returned a UNIX/Linux file path on Windows; however, the real implementation returned a Windows file path. 

This was fixed by ensuring that the file paths used were converted to the native operating system format.