### PR TITLE
minor bump of doublestar dependency to 1.0.10

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,62 +3,108 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:e6d502a383907444bca2c9527efdb88062fc12060c332d462067ddf9dffc6e7d"
   name = "code.cloudfoundry.org/clock"
   packages = [
     ".",
-    "fakeclock"
+    "fakeclock",
   ]
+  pruneopts = "NUT"
   revision = "2269160ae1757f96bbb8c6475e6fa36c805e73e0"
 
 [[projects]]
+  digest = "1:7294028ae4f4ebe9f92dccabdc69f63eba37b71fbfcdcb35ed1c32eb823fc6d4"
   name = "github.com/bmatcuk/doublestar"
   packages = ["."]
-  revision = "b3608229437ba4dc33dae64d56a79a2a73f1f6b2"
-  version = "v1.0.9"
+  pruneopts = "NUT"
+  revision = "85a78806aa1b4707d1dbace9be592cf1ece91ab3"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:58927c45bfdcd6550e5f1ab008eeeb6951474a232afa1dc690583f26c5f92cbd"
   name = "github.com/charlievieth/fs"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7dc373669fa10ddf827c37c595dee30a2f001be9"
 
 [[projects]]
   branch = "master"
+  digest = "1:0bf8cb53fd12f5c3d53d908ca9f23f436c5cc70e2058abdf404cb2d4c9f7aceb"
+  name = "github.com/cloudfoundry/bosh-utils"
+  packages = [
+    "assert",
+    "blobstore",
+    "blobstore/fakes",
+    "crypto",
+    "errors",
+    "fileutil",
+    "httpclient",
+    "logger",
+    "logger/fakes",
+    "logger/file",
+    "logger/loggerfakes",
+    "property",
+    "retrystrategy",
+    "system",
+    "system/fakes",
+    "uuid",
+    "uuid/fakes",
+    "work",
+  ]
+  pruneopts = "NUT"
+  revision = "c2cf699102bd7878141b9810117cba777852f1be"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3d3a6beb04065e29628f9d4f8fefeca4cc96932a8b0b83a03e9a3405b3538c11"
   name = "github.com/cloudfoundry/go-socks5"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "54f73bdb8a8e85a6611d3d29ab9bbf98c2a060d7"
 
 [[projects]]
   branch = "master"
+  digest = "1:5f29a6db136978d1515aa9909eacc36beeed758fe7d191dfa19fb8a86e42a5ce"
   name = "github.com/cloudfoundry/socks5-proxy"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3659db090cb23a57807b53e2f8580b2427dc2659"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b1ef763b6334cf7eb68249217b77955fdae4d2475e13d7d38eb4b452f0633944"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "NUT"
   revision = "17ce1425424ab154092bbb43af630bd647f3bb0d"
 
 [[projects]]
+  digest = "1:914f8eaa63b88fe6bcd656d81b3f3ccd2e8422df1787a6abe32554e4b75c0556"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "96dc06278ce32a0e9d957d590bb987c81ee66407"
   version = "v1.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:16bbae9910129be5a18b951eabacd54414d3faea094dfab92bb3c84884d46b11"
   name = "github.com/nu7hatch/gouuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
 
 [[projects]]
+  digest = "1:4b7ad06825a5ef932f35a66ac4a959facd323d70ed2106c7e2f3fcca07d66cc3"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -85,12 +131,14 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "9eda700730cba42af70d53180f9dcce9266bc2bc"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:bb57ca938a5e3e066614a83c16e56c0742791830194a037593615eaabd06cd0e"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -107,60 +155,74 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "c893efa28eb45626cdaa76c9f653b62488858837"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:59eb15a18373758cf4e964d15282dae2687d5dd0835099f6200821ca479c6514"
   name = "github.com/pivotal-cf/paraphernalia"
   packages = ["secure/tlsconfig"]
+  pruneopts = "NUT"
   revision = "e34e13867a42f12943d6d5448e90b294dc85601d"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:b5c8b4a0ad5f65a85eb2a9f89e30c638ef8b99f8a3f078467cea778869757666"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "NUT"
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
   branch = "master"
+  digest = "1:932c51bc69b71b4f207f7fe48eef9cebf9a318d53e8ad43d2a469c955f6d0a95"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
-    "ssh"
+    "ssh",
   ]
+  pruneopts = "NUT"
   revision = "2509b142fb2b797aa7587dad548f113b2c0f20ce"
 
 [[projects]]
   branch = "master"
+  digest = "1:999702ee97ddbb8b1192176a1aadd3ee3eb2d523e0452d9a48cfed0184ba3df2"
   name = "golang.org/x/net"
   packages = [
     "context",
     "html",
     "html/atom",
     "html/charset",
-    "proxy"
+    "proxy",
   ]
+  pruneopts = "NUT"
   revision = "66aacef3dd8a676686c7ae3716979581e8b03c47"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2deb8ce9667694902730153ad32302b1f9be9a64ce5e8f1d195c0938ab179d6"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "NUT"
   revision = "7a85bfad8bb9558204b9cc9b3624680d2d443a35"
 
 [[projects]]
   branch = "master"
+  digest = "1:9075d7a109601cf99e20150832299c84d17eb25799e11570c9d16739d8c290da"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -179,19 +241,57 @@
     "language",
     "runes",
     "transform",
-    "unicode/cldr"
+    "unicode/cldr",
   ]
+  pruneopts = "NUT"
   revision = "acd49d43e9b95df46670431bf5c7ae59586daad8"
 
 [[projects]]
   branch = "v2"
+  digest = "1:c85dc78b3426641ebf2a0bbf5b731b5c4613ddb5987dbe218f7e75468dcd56f5"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3a94ee7d808580ffcb21cf326cc0c41012a534179c4b8003661aa0c985ce0a43"
+  input-imports = [
+    "code.cloudfoundry.org/clock/fakeclock",
+    "github.com/bmatcuk/doublestar",
+    "github.com/charlievieth/fs",
+    "github.com/cloudfoundry/bosh-utils/assert",
+    "github.com/cloudfoundry/bosh-utils/blobstore",
+    "github.com/cloudfoundry/bosh-utils/blobstore/fakes",
+    "github.com/cloudfoundry/bosh-utils/crypto",
+    "github.com/cloudfoundry/bosh-utils/errors",
+    "github.com/cloudfoundry/bosh-utils/fileutil",
+    "github.com/cloudfoundry/bosh-utils/httpclient",
+    "github.com/cloudfoundry/bosh-utils/logger",
+    "github.com/cloudfoundry/bosh-utils/logger/fakes",
+    "github.com/cloudfoundry/bosh-utils/logger/file",
+    "github.com/cloudfoundry/bosh-utils/logger/loggerfakes",
+    "github.com/cloudfoundry/bosh-utils/property",
+    "github.com/cloudfoundry/bosh-utils/retrystrategy",
+    "github.com/cloudfoundry/bosh-utils/system",
+    "github.com/cloudfoundry/bosh-utils/system/fakes",
+    "github.com/cloudfoundry/bosh-utils/uuid",
+    "github.com/cloudfoundry/bosh-utils/uuid/fakes",
+    "github.com/cloudfoundry/bosh-utils/work",
+    "github.com/cloudfoundry/socks5-proxy",
+    "github.com/jessevdk/go-flags",
+    "github.com/nu7hatch/gouuid",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/ginkgo/ginkgo",
+    "github.com/onsi/gomega",
+    "github.com/onsi/gomega/gbytes",
+    "github.com/onsi/gomega/gexec",
+    "github.com/onsi/gomega/ghttp",
+    "github.com/pivotal-cf/paraphernalia/secure/tlsconfig",
+    "github.com/stretchr/testify/assert",
+    "golang.org/x/net/proxy",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,7 +7,7 @@ required = ["github.com/onsi/ginkgo/ginkgo"]
 
 [[constraint]]
   name = "github.com/bmatcuk/doublestar"
-  version = "1.0.9"
+  version = "1.0.10"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/bmatcuk/doublestar/doublestar.go
+++ b/vendor/github.com/bmatcuk/doublestar/doublestar.go
@@ -1,50 +1,61 @@
 package doublestar
 
 import (
-  "path/filepath"
-  "path"
-  "os"
-  "strings"
-  "unicode/utf8"
-  "fmt"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
 )
 
 var ErrBadPattern = path.ErrBadPattern
 
+// Split a path on the given separator, respecting escaping.
 func splitPathOnSeparator(path string, separator rune) []string {
-  // if the separator is '\\', then we can just split...
-  if separator == '\\' { return strings.Split(path, string(separator)) }
+	// if the separator is '\\', then we can just split...
+	if separator == '\\' {
+		return strings.Split(path, string(separator))
+	}
 
-  // otherwise, we need to be careful of situations where the separator was escaped
-  cnt := strings.Count(path, string(separator))
-  if cnt == 0 { return []string{path} }
-  ret := make([]string, cnt + 1)
-  pathlen := len(path)
-  separatorLen := utf8.RuneLen(separator)
-  idx := 0
-  for start := 0; start < pathlen; {
-    end := indexRuneWithEscaping(path[start:], separator)
-    if end == -1 {
-      end = pathlen
-    } else {
-      end += start
-    }
-    ret[idx] = path[start:end]
-    start = end + separatorLen
-    idx++
-  }
-  return ret[:idx]
+	// otherwise, we need to be careful of situations where the separator was escaped
+	cnt := strings.Count(path, string(separator))
+	if cnt == 0 {
+		return []string{path}
+	}
+	ret := make([]string, cnt+1)
+	pathlen := len(path)
+	separatorLen := utf8.RuneLen(separator)
+	idx := 0
+	for start := 0; start < pathlen; {
+		end := indexRuneWithEscaping(path[start:], separator)
+		if end == -1 {
+			end = pathlen
+		} else {
+			end += start
+		}
+		ret[idx] = path[start:end]
+		start = end + separatorLen
+		idx++
+	}
+	return ret[:idx]
 }
 
+// Find the first index of a rune in a string,
+// ignoring any times the rune is escaped using "\".
 func indexRuneWithEscaping(s string, r rune) int {
-  end := strings.IndexRune(s, r)
-  if end == -1 { return -1 }
-  if end > 0 && s[end - 1] == '\\' {
-    start := end + utf8.RuneLen(r)
-    end = indexRuneWithEscaping(s[start:], r)
-    if end != -1 { end += start }
-  }
-  return end
+	end := strings.IndexRune(s, r)
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		start := end + utf8.RuneLen(r)
+		end = indexRuneWithEscaping(s[start:], r)
+		if end != -1 {
+			end += start
+		}
+	}
+	return end
 }
 
 // Match returns true if name matches the shell file name pattern.
@@ -78,7 +89,7 @@ func indexRuneWithEscaping(s string, r rune) int {
 // is the PathMatch() function below.
 //
 func Match(pattern, name string) (bool, error) {
-  return matchWithSeparator(pattern, name, '/')
+	return matchWithSeparator(pattern, name, '/')
 }
 
 // PathMatch is like Match except that it uses your system's path separator.
@@ -89,7 +100,7 @@ func Match(pattern, name string) (bool, error) {
 // Note: this is meant as a drop-in replacement for filepath.Match().
 //
 func PathMatch(pattern, name string) (bool, error) {
-  return matchWithSeparator(pattern, name, os.PathSeparator)
+	return matchWithSeparator(pattern, name, os.PathSeparator)
 }
 
 // Match returns true if name matches the shell file name pattern.
@@ -118,33 +129,48 @@ func PathMatch(pattern, name string) (bool, error) {
 // is malformed.
 //
 func matchWithSeparator(pattern, name string, separator rune) (bool, error) {
-  patternComponents := splitPathOnSeparator(pattern, separator)
-  nameComponents := splitPathOnSeparator(name, separator)
-  return doMatching(patternComponents, nameComponents)
+	patternComponents := splitPathOnSeparator(pattern, separator)
+	nameComponents := splitPathOnSeparator(name, separator)
+	return doMatching(patternComponents, nameComponents)
 }
 
 func doMatching(patternComponents, nameComponents []string) (matched bool, err error) {
-  patternLen, nameLen := len(patternComponents), len(nameComponents)
-  if patternLen == 0 && nameLen == 0 { return true, nil }
-  if patternLen == 0 || nameLen == 0 { return false, nil }
-  patIdx, nameIdx := 0, 0
-  for ; patIdx < patternLen && nameIdx < nameLen; {
-    if patternComponents[patIdx] == "**" {
-      if patIdx++; patIdx >= patternLen { return true, nil }
-      for ; nameIdx < nameLen; nameIdx++ {
-        if m, _ := doMatching(patternComponents[patIdx:], nameComponents[nameIdx:]); m {
-          return true, nil
-        }
-      }
-      return false, nil
-    } else {
-      matched, err = matchComponent(patternComponents[patIdx], nameComponents[nameIdx])
-      if !matched || err != nil { return }
-    }
-    patIdx++
-    nameIdx++
-  }
-  return patIdx >= patternLen && nameIdx >= nameLen, nil
+	// check for some base-cases
+	patternLen, nameLen := len(patternComponents), len(nameComponents)
+	if patternLen == 0 && nameLen == 0 {
+		return true, nil
+	}
+	if patternLen == 0 || nameLen == 0 {
+		return false, nil
+	}
+
+	patIdx, nameIdx := 0, 0
+	for patIdx < patternLen && nameIdx < nameLen {
+		if patternComponents[patIdx] == "**" {
+			// if our last pattern component is a doublestar, we're done -
+			// doublestar will match any remaining name components, if any.
+			if patIdx++; patIdx >= patternLen {
+				return true, nil
+			}
+
+			// otherwise, try matching remaining components
+			for ; nameIdx < nameLen; nameIdx++ {
+				if m, _ := doMatching(patternComponents[patIdx:], nameComponents[nameIdx:]); m {
+					return true, nil
+				}
+			}
+			return false, nil
+		} else {
+			// try matching components
+			matched, err = matchComponent(patternComponents[patIdx], nameComponents[nameIdx])
+			if !matched || err != nil {
+				return
+			}
+		}
+		patIdx++
+		nameIdx++
+	}
+	return patIdx >= patternLen && nameIdx >= nameLen, nil
 }
 
 // Glob returns the names of all files matching pattern or nil
@@ -163,198 +189,267 @@ func doMatching(patternComponents, nameComponents []string) (matched bool, err e
 // Note: this is meant as a drop-in replacement for filepath.Glob().
 //
 func Glob(pattern string) (matches []string, err error) {
-  patternComponents := splitPathOnSeparator(pattern, os.PathSeparator)
-  if len(patternComponents) == 0 { return nil, nil }
+	patternComponents := splitPathOnSeparator(filepath.ToSlash(pattern), '/')
+	if len(patternComponents) == 0 {
+		return nil, nil
+	}
 
-  // On Windows systems, this will return the drive name ('C:'), on others,
-  // it will return an empty string.
-  volumeName := filepath.VolumeName(pattern)
+	// On Windows systems, this will return the drive name ('C:'), on others,
+	// it will return an empty string.
+	volumeName := filepath.VolumeName(pattern)
 
-  // If the first pattern component is equal to the volume name, then the
-  // pattern is an absolute path.
-  if patternComponents[0] == volumeName {
-    return doGlob(fmt.Sprintf("%s%s", volumeName, string(os.PathSeparator)), patternComponents[1:], matches)
-  }
-  return doGlob(".", patternComponents, matches)
+	// If the first pattern component is equal to the volume name, then the
+	// pattern is an absolute path.
+	if patternComponents[0] == volumeName {
+		return doGlob(fmt.Sprintf("%s%s", volumeName, string(os.PathSeparator)), patternComponents[1:], matches)
+	}
+
+	// otherwise, it's a relative pattern
+	return doGlob(".", patternComponents, matches)
 }
 
+// Perform a glob
 func doGlob(basedir string, components, matches []string) (m []string, e error) {
-  m = matches
-  e = nil
+	m = matches
+	e = nil
 
-  // figure out how many components we don't need to glob because they're
-  // just straight directory names
-  patLen := len(components)
-  patIdx := 0
-  for ; patIdx < patLen; patIdx++ {
-    if strings.IndexAny(components[patIdx], "*?[{\\") >= 0 { break }
-  }
-  if patIdx > 0 {
-    basedir = filepath.Join(basedir, filepath.Join(components[0:patIdx]...))
-  }
+	// figure out how many components we don't need to glob because they're
+	// just names without patterns - we'll use os.Lstat below to check if that
+	// path actually exists
+	patLen := len(components)
+	patIdx := 0
+	for ; patIdx < patLen; patIdx++ {
+		if strings.IndexAny(components[patIdx], "*?[{\\") >= 0 {
+			break
+		}
+	}
+	if patIdx > 0 {
+		basedir = filepath.Join(basedir, filepath.Join(components[0:patIdx]...))
+	}
 
-  // Stat will return an error if the file/directory doesn't exist
-  fi, err := os.Lstat(basedir)
-  if err != nil { return }
+	// Lstat will return an error if the file/directory doesn't exist
+	fi, err := os.Lstat(basedir)
+	if err != nil {
+		return
+	}
 
-  // if there are no more components, we've found a match
-  if patIdx >= patLen {
-    m = append(m, basedir)
-    return
-  }
+	// if there are no more components, we've found a match
+	if patIdx >= patLen {
+		m = append(m, basedir)
+		return
+	}
 
-  // otherwise, we need to check each item in the directory...
-  // first, if basedir is a symlink, follow it...
-  if fi.Mode() & os.ModeSymlink != 0 {
-    fi, err = os.Stat(basedir)
-    if err != nil { return }
-  }
+	// otherwise, we need to check each item in the directory...
+	// first, if basedir is a symlink, follow it...
+	if (fi.Mode() & os.ModeSymlink) != 0 {
+		fi, err = os.Stat(basedir)
+		if err != nil {
+			return
+		}
+	}
 
-  // confirm it's a directory...
-  if !fi.IsDir() { return }
+	// confirm it's a directory...
+	if !fi.IsDir() {
+		return
+	}
 
-  // read directory
-  dir, err := os.Open(basedir)
-  if err != nil { return }
-  defer dir.Close()
+	// read directory
+	dir, err := os.Open(basedir)
+	if err != nil {
+		return
+	}
+	defer dir.Close()
 
-  files, _ := dir.Readdir(-1)
-  lastComponent := patIdx + 1 >= patLen
-  if components[patIdx] == "**" {
-    // if the current component is a doublestar, we'll try depth-first
-    for _, file := range files {
-      // if symlink, we may want to follow
-      if file.Mode() & os.ModeSymlink != 0 {
-        file, err = os.Stat(filepath.Join(basedir, file.Name()))
-        if err != nil { continue }
-      }
+	files, _ := dir.Readdir(-1)
+	lastComponent := (patIdx + 1) >= patLen
+	if components[patIdx] == "**" {
+		// if the current component is a doublestar, we'll try depth-first
+		for _, file := range files {
+			// if symlink, we may want to follow
+			if (file.Mode() & os.ModeSymlink) != 0 {
+				file, err = os.Stat(filepath.Join(basedir, file.Name()))
+				if err != nil {
+					continue
+				}
+			}
 
-      if file.IsDir() {
-        if lastComponent {
-          m = append(m, filepath.Join(basedir, file.Name()))
-        }
-        m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx:], m)
-      } else if lastComponent {
-        // if the pattern's last component is a doublestar, we match filenames, too
-        m = append(m, filepath.Join(basedir, file.Name()))
-      }
-    }
-    if lastComponent { return }
-    patIdx++
-    lastComponent = patIdx + 1 >= patLen
-  }
+			if file.IsDir() {
+				// recurse into directories
+				if lastComponent {
+					m = append(m, filepath.Join(basedir, file.Name()))
+				}
+				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx:], m)
+			} else if lastComponent {
+				// if the pattern's last component is a doublestar, we match filenames, too
+				m = append(m, filepath.Join(basedir, file.Name()))
+			}
+		}
+		if lastComponent {
+			return // we're done
+		}
+		patIdx++
+		lastComponent = (patIdx + 1) >= patLen
+	}
 
-  var match bool
-  for _, file := range files {
-    match, e = matchComponent(components[patIdx], file.Name())
-    if e != nil { return }
-    if match {
-      if lastComponent {
-        m = append(m, filepath.Join(basedir, file.Name()))
-      } else {
-        m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx + 1:], m)
-      }
-    }
-  }
-  return
+	// check items in current directory and recurse
+	var match bool
+	for _, file := range files {
+		match, e = matchComponent(components[patIdx], file.Name())
+		if e != nil {
+			return
+		}
+		if match {
+			if lastComponent {
+				m = append(m, filepath.Join(basedir, file.Name()))
+			} else {
+				m, e = doGlob(filepath.Join(basedir, file.Name()), components[patIdx+1:], m)
+			}
+		}
+	}
+	return
 }
 
+// Attempt to match a single pattern component with a path component
 func matchComponent(pattern, name string) (bool, error) {
-  patternLen, nameLen := len(pattern), len(name)
-  if patternLen == 0 && nameLen == 0 { return true, nil }
-  if patternLen == 0 { return false, nil }
-  if nameLen == 0 && pattern != "*" { return false, nil }
-  patIdx, nameIdx := 0, 0
-  for ; patIdx < patternLen && nameIdx < nameLen; {
-    patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
-    nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
-    if patRune == '\\' {
-      patIdx += patAdj
-      patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
-      if patRune == utf8.RuneError {
-        return false, ErrBadPattern
-      } else if patRune == nameRune {
-        patIdx += patAdj
-        nameIdx += nameAdj
-      } else {
-        return false, nil
-      }
-    } else if patRune == '*' {
-      if patIdx += patAdj; patIdx >= patternLen { return true, nil }
-      for ; nameIdx < nameLen; nameIdx += nameAdj {
-        if m, _ := matchComponent(pattern[patIdx:], name[nameIdx:]); m {
-          return true, nil
-        }
-      }
-      return false, nil
-    } else if patRune == '[' {
-      patIdx += patAdj
-      endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
-      if endClass == -1 { return false, ErrBadPattern }
-      endClass += patIdx
-      classRunes := []rune(pattern[patIdx:endClass])
-      classRunesLen := len(classRunes)
-      if classRunesLen > 0 {
-        classIdx := 0
-        matchClass := false
-        if classRunes[0] == '^' { classIdx++ }
-        for classIdx < classRunesLen {
-          low := classRunes[classIdx]
-          if low == '-' { return false, ErrBadPattern }
-          classIdx++
-          if low == '\\' {
-            if classIdx < classRunesLen {
-              low = classRunes[classIdx]
-              classIdx++
-            } else {
-              return false, ErrBadPattern
-            }
-          }
-          high := low
-          if classIdx < classRunesLen && classRunes[classIdx] == '-' {
-            if classIdx++; classIdx >= classRunesLen { return false, ErrBadPattern }
-            high = classRunes[classIdx]
-            if high == '-' { return false, ErrBadPattern }
-            classIdx++
-            if high == '\\' {
-              if classIdx < classRunesLen {
-                high = classRunes[classIdx]
-                classIdx++
-              } else {
-                return false, ErrBadPattern
-              }
-            }
-          }
-          if low <= nameRune && nameRune <= high { matchClass = true }
-        }
-        if matchClass == (classRunes[0] == '^') { return false, nil }
-      } else {
-        return false, ErrBadPattern
-      }
-      patIdx = endClass + 1
-      nameIdx += nameAdj
-    } else if patRune == '{' {
-      patIdx += patAdj
-      endOptions := indexRuneWithEscaping(pattern[patIdx:], '}')
-      if endOptions == -1 { return false, ErrBadPattern }
-      endOptions += patIdx
-      options := splitPathOnSeparator(pattern[patIdx:endOptions], ',')
-      patIdx = endOptions + 1
-      for _, o := range options {
-        m, e := matchComponent(o + pattern[patIdx:], name[nameIdx:])
-        if e != nil { return false, e }
-        if m { return true, nil }
-      }
-      return false, nil
-    } else if patRune == '?' || patRune == nameRune {
-      patIdx += patAdj
-      nameIdx += nameAdj
-    } else {
-      return false, nil
-    }
-  }
-  if patIdx >= patternLen && nameIdx >= nameLen { return true, nil }
-  if nameIdx >= nameLen && pattern[patIdx:] == "*" || pattern[patIdx:] == "**" { return true, nil }
-  return false, nil
-}
+	// check some base cases
+	patternLen, nameLen := len(pattern), len(name)
+	if patternLen == 0 && nameLen == 0 {
+		return true, nil
+	}
+	if patternLen == 0 {
+		return false, nil
+	}
+	if nameLen == 0 && pattern != "*" {
+		return false, nil
+	}
 
+	// check for matches one rune at a time
+	patIdx, nameIdx := 0, 0
+	for patIdx < patternLen && nameIdx < nameLen {
+		patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
+		nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
+		if patRune == '\\' {
+			// handle escaped runes
+			patIdx += patAdj
+			patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
+			if patRune == utf8.RuneError {
+				return false, ErrBadPattern
+			} else if patRune == nameRune {
+				patIdx += patAdj
+				nameIdx += nameAdj
+			} else {
+				return false, nil
+			}
+		} else if patRune == '*' {
+			// handle stars
+			if patIdx += patAdj; patIdx >= patternLen {
+				// a star at the end of a pattern will always
+				// match the rest of the path
+				return true, nil
+			}
+
+			// check if we can make any matches
+			for ; nameIdx < nameLen; nameIdx += nameAdj {
+				if m, _ := matchComponent(pattern[patIdx:], name[nameIdx:]); m {
+					return true, nil
+				}
+			}
+			return false, nil
+		} else if patRune == '[' {
+			// handle character sets
+			patIdx += patAdj
+			endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
+			if endClass == -1 {
+				return false, ErrBadPattern
+			}
+			endClass += patIdx
+			classRunes := []rune(pattern[patIdx:endClass])
+			classRunesLen := len(classRunes)
+			if classRunesLen > 0 {
+				classIdx := 0
+				matchClass := false
+				if classRunes[0] == '^' {
+					classIdx++
+				}
+				for classIdx < classRunesLen {
+					low := classRunes[classIdx]
+					if low == '-' {
+						return false, ErrBadPattern
+					}
+					classIdx++
+					if low == '\\' {
+						if classIdx < classRunesLen {
+							low = classRunes[classIdx]
+							classIdx++
+						} else {
+							return false, ErrBadPattern
+						}
+					}
+					high := low
+					if classIdx < classRunesLen && classRunes[classIdx] == '-' {
+						// we have a range of runes
+						if classIdx++; classIdx >= classRunesLen {
+							return false, ErrBadPattern
+						}
+						high = classRunes[classIdx]
+						if high == '-' {
+							return false, ErrBadPattern
+						}
+						classIdx++
+						if high == '\\' {
+							if classIdx < classRunesLen {
+								high = classRunes[classIdx]
+								classIdx++
+							} else {
+								return false, ErrBadPattern
+							}
+						}
+					}
+					if low <= nameRune && nameRune <= high {
+						matchClass = true
+					}
+				}
+				if matchClass == (classRunes[0] == '^') {
+					return false, nil
+				}
+			} else {
+				return false, ErrBadPattern
+			}
+			patIdx = endClass + 1
+			nameIdx += nameAdj
+		} else if patRune == '{' {
+			// handle alternatives such as {alt1,alt2,...}
+			patIdx += patAdj
+			endOptions := indexRuneWithEscaping(pattern[patIdx:], '}')
+			if endOptions == -1 {
+				return false, ErrBadPattern
+			}
+			endOptions += patIdx
+			options := splitPathOnSeparator(pattern[patIdx:endOptions], ',')
+			patIdx = endOptions + 1
+			for _, o := range options {
+				m, e := matchComponent(o+pattern[patIdx:], name[nameIdx:])
+				if e != nil {
+					return false, e
+				}
+				if m {
+					return true, nil
+				}
+			}
+			return false, nil
+		} else if patRune == '?' || patRune == nameRune {
+			// handle single-rune wildcard
+			patIdx += patAdj
+			nameIdx += nameAdj
+		} else {
+			return false, nil
+		}
+	}
+	if patIdx >= patternLen && nameIdx >= nameLen {
+		return true, nil
+	}
+	if nameIdx >= nameLen && pattern[patIdx:] == "*" || pattern[patIdx:] == "**" {
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
In doublestar 1.0.9, if you tried to build this project in Go 1.11 via Modules, you'll get this error...

```
../../go/pkg/mod/github.com/cloudfoundry/bosh-utils@v0.0.0-20180315210917-c6a922e299b8/system/os_file_system.go:14:2: unknown import path "github.com/bmatcuk/doublestar": unzip .../go/pkg/mod/cache/download/github.com/bmatcuk/doublestar/@v/v1.0.9.zip: malformed file path "test/a☺b": invalid char '☺'
```

This minor bump will remove this error for this project and all others that depend on it (ie. cf cli).