### PR TITLE
Send SSH keep-alives on one minute intervals

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,12 +37,12 @@
   revision = "54f73bdb8a8e85a6611d3d29ab9bbf98c2a060d7"
 
 [[projects]]
-  digest = "1:d43a203ecd5644f46eeaef9dad5a11a06598ed6feb17cb6e232a2589d8e96347"
+  digest = "1:6422faebc7a4f3c8f58ff0af81002db6bd2f09204d6005611415163091947ad1"
   name = "github.com/cloudfoundry/socks5-proxy"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "7ade90b228c8472a45c189e77f78497b93bbaeaa"
-  version = "v0.1.0"
+  revision = "633b6fe4c3d8d72a4e7397a948027db02a8e2a96"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,4 +43,4 @@ required = ["github.com/onsi/ginkgo/ginkgo"]
 
 [[constraint]]
   name = "github.com/cloudfoundry/socks5-proxy"
-  version = "v0.1.0"
+  version = "v0.2.0"

--- a/httpclient/default_http_clients.go
+++ b/httpclient/default_http_clients.go
@@ -17,7 +17,7 @@ var (
 	defaultDialer = SOCKS5DialFuncFromEnvironment((&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-	}).Dial, proxy.NewSocks5Proxy(proxy.NewHostKey(), log.New(ioutil.Discard, "", log.LstdFlags)))
+	}).Dial, proxy.NewSocks5Proxy(proxy.NewHostKey(), log.New(ioutil.Discard, "", log.LstdFlags), 1*time.Minute))
 )
 
 type Client interface {

--- a/vendor/github.com/cloudfoundry/socks5-proxy/ssh_test_server.go
+++ b/vendor/github.com/cloudfoundry/socks5-proxy/ssh_test_server.go
@@ -5,13 +5,50 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
 
+const jb = "jumpbox"
+
+type checker struct {
+	expired         bool
+	timeout         time.Duration
+	lastMessageTime time.Time
+	sync.RWMutex
+}
+
+func (c *checker) check(reqs <-chan *ssh.Request) {
+	for {
+		select {
+		case req, ok := <-reqs:
+			if !ok {
+				continue
+			}
+
+			if req.Type == "bosh-cli-keep-alive@bosh.io" {
+				c.lastMessageTime = time.Now()
+			}
+
+			if req.WantReply {
+				req.Reply(false, nil)
+			}
+
+		default:
+			if c.lastMessageTime.Add(c.timeout).Before(time.Now()) {
+				c.Lock()
+				c.expired = true
+				c.Unlock()
+			}
+		}
+	}
+}
+
 func StartTestSSHServer(httpServerURL, sshPrivateKey, userName string) string {
 	if userName == "" {
-		userName = "jumpbox"
+		userName = jb
 	}
 
 	signer, err := ssh.ParsePrivateKey([]byte(sshPrivateKey))
@@ -38,6 +75,10 @@ func StartTestSSHServer(httpServerURL, sshPrivateKey, userName string) string {
 	if err != nil {
 		log.Fatal("failed to listen for connection: ", err)
 	}
+	c := &checker{
+		lastMessageTime: time.Now(),
+		timeout:         500 * time.Millisecond,
+	}
 
 	go func() {
 		for {
@@ -52,13 +93,23 @@ func StartTestSSHServer(httpServerURL, sshPrivateKey, userName string) string {
 				continue
 			}
 
-			go ssh.DiscardRequests(reqs)
+			go c.check(reqs)
 
 			for newChannel := range chans {
 				if newChannel.ChannelType() != "direct-tcpip" {
 					newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
 					continue
 				}
+
+				c.RLock()
+				expired := c.expired
+				c.RUnlock()
+
+				if expired {
+					newChannel.Reject(ssh.ConnectionFailed, "no keepalive sent, you died")
+					continue
+				}
+
 				channel, _, err := newChannel.Accept()
 				if err != nil {
 					log.Fatalf("Could not accept channel: %v", err)


### PR DESCRIPTION
After tracking down an issue with `bbl up` failing on a particular version of the Azure stemcell, we found out that our SSH connection gets severed due to idleness from the client. We made a fix to the socks5 proxy to send a keep alive message to keep the connection fresh 😎  and this pulls that fix into bosh-utils

cc @notrepo05  @zachgersh