### PR TITLE
Use golang os.UserHomeDir to get current user home directory

### DIFF
--- a/system/os_file_system.go
+++ b/system/os_file_system.go
@@ -46,7 +46,7 @@ func (fs *osFileSystem) ExpandPath(path string) (string, error) {
 	fs.logger.Debug(fs.logTag, "Expanding path for '%s'", path)
 
 	if strings.HasPrefix(path, "~") {
-		home, err := fs.currentHomeDir()
+		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", bosherr.WrapError(err, "Getting current user home dir")
 		}

--- a/system/os_file_system_unix.go
+++ b/system/os_file_system_unix.go
@@ -3,10 +3,10 @@
 package system
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"errors"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
@@ -19,10 +19,6 @@ func (fs *osFileSystem) homeDir(username string) (string, error) {
 		return "", bosherr.Errorf("Failed to get user '%s' home directory", username)
 	}
 	return homeDir, nil
-}
-
-func (fs *osFileSystem) currentHomeDir() (string, error) {
-	return fs.HomeDir("")
 }
 
 func (fs *osFileSystem) chown(path, owner string) error {

--- a/system/os_file_system_windows.go
+++ b/system/os_file_system_windows.go
@@ -7,19 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
-
-func (fs *osFileSystem) currentHomeDir() (string, error) {
-	t, err := syscall.OpenCurrentProcessToken()
-	if err != nil {
-		return "", err
-	}
-	defer t.Close()
-	return t.GetUserProfileDirectory()
-}
 
 func (fs *osFileSystem) homeDir(username string) (string, error) {
 	u, err := user.Current()


### PR DESCRIPTION
os.UserHomeDir is platform agnostic and respects platform specific
environment variables for home directory.

The specific issue we are seeing is on our Concourse windows worker. Ephemeral disk is mounted to D:\ drive. Current implementation of bosh-utils gets home directory for current user which is C:\Windows\system32\config\systemprofile. This results in bosh cli creating a `.bosh` directory in there with blobs downloads and caches. As a result our worker is running out of space on C drive even though it has enough of ephemeral disk. There is no way to change the home directory on Windows with environment variables with current implementation. Using `os.UserHomeDir` will make it respect environment variables like `USERPROFILE` for windows. https://golang.org/src/os/file.go?s=11606:11640#L379

Tests passed both on Linux and Windows.