### PR TITLE
switch tlsconfig.WithInternalServiceDefaults with External

### DIFF
--- a/httpclient/default_http_clients.go
+++ b/httpclient/default_http_clients.go
@@ -40,7 +40,7 @@ type factory struct{}
 
 func (f factory) New(insecureSkipVerify bool, certPool *x509.CertPool) *http.Client {
 	tlsConfig, err := tlsconfig.Build(
-		tlsconfig.WithInternalServiceDefaults(),
+		tlsconfig.WithExternalServiceDefaults(),
 		WithInsecureSkipVerify(insecureSkipVerify),
 		WithClientSessionCache(0),
 	).Client(tlsconfig.WithAuthority(certPool))


### PR DESCRIPTION
The bosh agent fails sending requests with certain signed URLs (GCP for example) when tlsconfig does not include necessary cipher suites.

Without this change we would get compilation failures using a _windows_ stemcell + latest bosh agent. The logs deployment logs would output the following:

```
Action Failed get_task: Task 0114cfa3-75d9-4871-41b0-7cf255d69756 result: Compiling package golang-1-windows: Fetching package golang-1-windows: Fetching package blob : Excuting GET request: Get <REDACTED SIGNED URL>&X-Goog-SignedHeaders=host: remote error: tls: handshake failure
```

### Deployment:
```yaml
instance_groups:
- azs:
  - z1
  instances: 1
  lifecycle: service
  name: hello
  networks:
  - name: default
  stemcell: windows
  vm_type: default
  jobs: []
name: hello2019-agent-test
releases: []
stemcells:
- alias: windows
  os: windows2019
  version: latest
update:
  canaries: 1
  canary_watch_time: 30000-300000
  max_errors: 2
  max_in_flight: 1
  serial: false
  update_watch_time: 30000-300000
```

Related Tracker Story: Bump BOSH agent to version 2.297 [#171540528](https://www.pivotaltracker.com/story/show/171540528)