### PR TITLE
Move keepalive to new explicit http client

### DIFF
--- a/httpclient/default_http_clients.go
+++ b/httpclient/default_http_clients.go
@@ -29,24 +29,34 @@ type Client interface {
 func CreateDefaultClient(certPool *x509.CertPool) *http.Client {
 	insecureSkipVerify := false
 	external := false
-	return factory{}.New(insecureSkipVerify, external, certPool)
+	disableKeepAlives := true
+	return factory{}.New(insecureSkipVerify, external, disableKeepAlives, certPool)
 }
 
 func CreateExternalDefaultClient(certPool *x509.CertPool) *http.Client {
 	insecureSkipVerify := false
 	external := true
-	return factory{}.New(insecureSkipVerify, external, certPool)
+	disableKeepAlives := true
+	return factory{}.New(insecureSkipVerify, external, disableKeepAlives, certPool)
+}
+
+func CreateKeepAliveDefaultClient(certPool *x509.CertPool) *http.Client {
+	insecureSkipVerify := false
+	external := true
+	disableKeepAlives := false
+	return factory{}.New(insecureSkipVerify, external, disableKeepAlives, certPool)
 }
 
 func CreateDefaultClientInsecureSkipVerify() *http.Client {
 	insecureSkipVerify := true
 	external := false
-	return factory{}.New(insecureSkipVerify, external, nil)
+	disableKeepAlives := true
+	return factory{}.New(insecureSkipVerify, external, disableKeepAlives, nil)
 }
 
 type factory struct{}
 
-func (f factory) New(insecureSkipVerify, externalClient bool, certPool *x509.CertPool) *http.Client {
+func (f factory) New(insecureSkipVerify, externalClient bool, disableKeepAlives bool, certPool *x509.CertPool) *http.Client {
 	serviceDefaults := tlsconfig.WithInternalServiceDefaults()
 	if externalClient {
 		serviceDefaults = tlsconfig.WithExternalServiceDefaults()
@@ -67,6 +77,7 @@ func (f factory) New(insecureSkipVerify, externalClient bool, certPool *x509.Cer
 			Proxy:               http.ProxyFromEnvironment,
 			DialContext:         defaultDialerContextFunc,
 			TLSHandshakeTimeout: 30 * time.Second,
+			DisableKeepAlives:   disableKeepAlives,
 		},
 	}
 

--- a/httpclient/default_http_clients_test.go
+++ b/httpclient/default_http_clients_test.go
@@ -17,6 +17,12 @@ var _ = Describe("Default HTTP clients", func() {
 			Expect(client).ToNot(BeNil())
 			Expect(client).To(Equal(DefaultClient))
 		})
+		It("disables HTTP Transport keep-alive (disables HTTP/1.[01] connection reuse)", func() {
+			var client *http.Client
+			client = DefaultClient
+
+			Expect(client.Transport.(*http.Transport).DisableKeepAlives).To(Equal(true))
+		})
 	})
 
 	Describe("CreateDefaultClient", func() {
@@ -25,8 +31,30 @@ var _ = Describe("Default HTTP clients", func() {
 			Expect(client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify).To(Equal(false))
 		})
 
+		It("disables HTTP Transport keep-alive (disables HTTP/1.[01] connection reuse)", func() {
+			client := CreateDefaultClient(nil)
+			Expect(client.Transport.(*http.Transport).DisableKeepAlives).To(Equal(true))
+		})
+
 		It("sets a TLS Session Cache", func() {
 			client := CreateDefaultClient(nil)
+			Expect(client.Transport.(*http.Transport).TLSClientConfig.ClientSessionCache).To(Equal(tls.NewLRUClientSessionCache(0)))
+		})
+	})
+
+	Describe("CreateKeepAliveDefaultClient", func() {
+		It("enforces ssl verification", func() {
+			client := CreateKeepAliveDefaultClient(nil)
+			Expect(client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify).To(Equal(false))
+		})
+
+		It("disables HTTP Transport keep-alive (disables HTTP/1.[01] connection reuse)", func() {
+			client := CreateKeepAliveDefaultClient(nil)
+			Expect(client.Transport.(*http.Transport).DisableKeepAlives).To(Equal(false))
+		})
+
+		It("sets a TLS Session Cache", func() {
+			client := CreateKeepAliveDefaultClient(nil)
 			Expect(client.Transport.(*http.Transport).TLSClientConfig.ClientSessionCache).To(Equal(tls.NewLRUClientSessionCache(0)))
 		})
 	})
@@ -35,6 +63,11 @@ var _ = Describe("Default HTTP clients", func() {
 		It("skips ssl verification", func() {
 			client := CreateDefaultClientInsecureSkipVerify()
 			Expect(client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify).To(Equal(true))
+		})
+
+		It("disables HTTP Transport keep-alive (disables HTTP/1.[01] connection reuse)", func() {
+			client := CreateDefaultClientInsecureSkipVerify()
+			Expect(client.Transport.(*http.Transport).DisableKeepAlives).To(Equal(true))
 		})
 	})
 })


### PR DESCRIPTION
We have noticed some production issues with enabling keepalive for all uses of DefaultHttpClient.  This PR reverts that change and adds an explicit CreateKeepAliveDefaultClient function for clients which benefits from this setting. 

[#173690103](https://www.pivotaltracker.com/story/show/173690103)