### PR TITLE
Loosen chiper requirements for default client

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,6 @@
 export GOPATH=$PWD/../../../..
 export PATH=$GOPATH/bin:$PATH
+
+if command -v lorri &> /dev/null; then
+   eval "$(lorri direnv)"
+fi

--- a/httpclient/default_http_clients.go
+++ b/httpclient/default_http_clients.go
@@ -49,7 +49,7 @@ func CreateKeepAliveDefaultClient(certPool *x509.CertPool) *http.Client {
 
 func CreateDefaultClientInsecureSkipVerify() *http.Client {
 	insecureSkipVerify := true
-	external := false
+	external := true
 	disableKeepAlives := true
 	return factory{}.New(insecureSkipVerify, external, disableKeepAlives, nil)
 }

--- a/httpclient/default_http_clients_test.go
+++ b/httpclient/default_http_clients_test.go
@@ -69,5 +69,11 @@ var _ = Describe("Default HTTP clients", func() {
 			client := CreateDefaultClientInsecureSkipVerify()
 			Expect(client.Transport.(*http.Transport).DisableKeepAlives).To(Equal(true))
 		})
+
+		It("allows external CipherSuites for example: tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", func() {
+			client := CreateDefaultClientInsecureSkipVerify()
+			Expect(client.Transport.(*http.Transport).TLSClientConfig.CipherSuites).
+				To(ContainElement(tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305))
+		})
 	})
 })


### PR DESCRIPTION
The default client is used by the bosh cli to fetch stemcells which
are now hosted on gcp. Gcp uses ECDHE-ECDSA-CHACHA20-POLY1305 chiper
which is included the ciphers allowed by WithExternalServiceDefaults

Related story: https://www.pivotaltracker.com/story/show/178496547