### PR TITLE
Fix improper popping of command results

### DIFF
--- a/system/fakes/fake_cmd_runner.go
+++ b/system/fakes/fake_cmd_runner.go
@@ -219,7 +219,11 @@ func (r *FakeCmdRunner) getOutputsForCmd(runCmd []string) (string, string, int, 
 		}
 
 		if !result.Sticky {
-			r.commandResults[fullCmd] = newResults
+			if len(newResults) == 0 {
+				delete(r.commandResults, "fullCmd")
+			} else {
+				r.commandResults[fullCmd] = newResults
+			}
 		}
 
 		return result.Stdout, result.Stderr, result.ExitStatus, result.Error

--- a/system/fakes/fake_cmd_runner.go
+++ b/system/fakes/fake_cmd_runner.go
@@ -220,7 +220,7 @@ func (r *FakeCmdRunner) getOutputsForCmd(runCmd []string) (string, string, int, 
 
 		if !result.Sticky {
 			if len(newResults) == 0 {
-				delete(r.commandResults, "fullCmd")
+				delete(r.commandResults, fullCmd)
 			} else {
 				r.commandResults[fullCmd] = newResults
 			}

--- a/system/fakes/fake_cmd_runner_test.go
+++ b/system/fakes/fake_cmd_runner_test.go
@@ -14,7 +14,7 @@ var _ = Describe("FakeCmdRunner", func() {
 	)
 
 	BeforeEach(func() {
-		runner = &FakeCmdRunner{}
+		runner = NewFakeCmdRunner()
 	})
 
 	Describe("RunCommandQuietly", func() {
@@ -27,6 +27,30 @@ var _ = Describe("FakeCmdRunner", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(runner.RunCommandsQuietly).To(Equal([][]string{{"foo", "bar"}}))
+		})
+	})
+
+	Describe("RunCommand", func() {
+		BeforeEach(func() {
+			runner.AddCmdResult(
+				"foo bar",
+				FakeCmdResult{Stdout: "nice"},
+			)
+		})
+
+		It("pops first result", func() {
+			_, _, _, err := runner.RunCommand("foo", "bar")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(runner.RunCommands).To(Equal([][]string{{"foo", "bar"}}))
+		})
+
+		It("pops first result then succeeds properly", func() {
+			_, _, _, err := runner.RunCommand("foo", "bar")
+			_, _, _, err = runner.RunCommand("foo", "bar")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(runner.RunCommands).To(Equal([][]string{{"foo", "bar"}, {"foo", "bar"}}))
 		})
 	})
 })


### PR DESCRIPTION
While working on the BOSH Agent, we've hit this issue with fake command runner that it improperly pops the command results, which leads to panics.
This PR demonstrates the problem and fixes the issue.
Cheers mates