### PR TITLE
Fix flaky keepalive syscall unit test

### DIFF
--- a/httpclient/keepalive_syscall_linux_test.go
+++ b/httpclient/keepalive_syscall_linux_test.go
@@ -3,6 +3,7 @@ package httpclient_test
 import (
 	"context"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,7 @@ var _ = Describe("Linux-specific tests", func() {
 
 			ln, err := net.Listen("tcp", laddr)
 			Expect(err).ToNot(HaveOccurred())
+			time.Sleep(3 * time.Second)
 
 			readyToAccept <- true
 


### PR DESCRIPTION
Adding a sleep of 3 seconds after invoking `net.Listen("tcp", laddr)`. This function seems to be executing without errors, but failing to open the tcp port synchronously.

Fixes:
```
socks connect tcp 127.0.0.1:22->127.0.0.1:19642: dial tcp 127.0.0.1:22: connect: connection refused
  occurred

  /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-utils/httpclient/keepalive_syscall_linux_test.go:43
```