### PR TITLE
Add FilteredMultiCopyToTemp function to genericCpCopier

### DIFF
--- a/fileutil/copier_interface.go
+++ b/fileutil/copier_interface.go
@@ -1,6 +1,7 @@
 package fileutil
 
 type Copier interface {
+	FilteredMultiCopyToTemp(dirs []DirToCopy, filters []string) (string, error)
 	FilteredCopyToTemp(dir string, filters []string) (tempDir string, err error)
 	CleanUp(tempDir string)
 }

--- a/fileutil/fakes/fake_copier.go
+++ b/fileutil/fakes/fake_copier.go
@@ -1,10 +1,16 @@
 package fakes
 
+import "github.com/cloudfoundry/bosh-utils/fileutil"
+
 type FakeCopier struct {
-	FilteredCopyToTempTempDir string
-	FilteredCopyToTempError   error
-	FilteredCopyToTempDir     string
-	FilteredCopyToTempFilters []string
+	FilteredCopyToTempTempDir      string
+	FilteredCopyToTempError        error
+	FilteredCopyToTempDir          string
+	FilteredCopyToTempFilters      []string
+	FilteredMultiCopyToTempDirs    []fileutil.DirToCopy
+	FilteredMultiCopyToTempFilters []string
+	FilteredMultiCopyToTempError   error
+	FilteredMultiCopyToTempDir     string
 
 	CleanUpTempDir string
 }
@@ -19,6 +25,14 @@ func (c *FakeCopier) FilteredCopyToTemp(dir string, filters []string) (tempDir s
 	c.FilteredCopyToTempFilters = filters
 	tempDir = c.FilteredCopyToTempTempDir
 	err = c.FilteredCopyToTempError
+	return
+}
+
+func (c *FakeCopier) FilteredMultiCopyToTemp(dirs []fileutil.DirToCopy, filters []string) (tempDir string, err error) {
+	c.FilteredMultiCopyToTempDirs = dirs
+	c.FilteredMultiCopyToTempFilters = filters
+	tempDir = c.FilteredMultiCopyToTempDir
+	err = c.FilteredMultiCopyToTempError
 	return
 }
 

--- a/fileutil/generic_cp_copier.go
+++ b/fileutil/generic_cp_copier.go
@@ -14,6 +14,11 @@ import (
 
 const genericCpCopierLogTag = "genericCpCopier"
 
+type DirToCopy struct {
+	Dir    string
+	Prefix string
+}
+
 type genericCpCopier struct {
 	fs     boshsys.FileSystem
 	logger boshlog.Logger
@@ -27,68 +32,44 @@ func NewGenericCpCopier(
 }
 
 func (c genericCpCopier) FilteredCopyToTemp(dir string, filters []string) (string, error) {
-	var filtersFilesToCopy []string
-	var err error
-
-	filters = c.convertDirectoriesToGlobs(dir, filters)
-
-	filesToCopy := []string{}
-
-	for _, filterPath := range filters {
-		filtersFilesToCopy, err = doublestar.Glob(filterPath)
-		if err != nil {
-			return "", bosherr.WrapError(err, "Finding files matching filters")
-		}
-
-		for _, fileToCopy := range filtersFilesToCopy {
-			filesToCopy = append(filesToCopy, strings.TrimPrefix(strings.TrimPrefix(fileToCopy, dir), "/"))
-		}
-	}
-
-	return c.tryInTempDir(func(tempDir string) error {
-		for _, relativePath := range filesToCopy {
-			src := filepath.Join(dir, relativePath)
-			dst := filepath.Join(tempDir, relativePath)
-
-			fileInfo, err := os.Stat(src)
-			if err != nil {
-				return bosherr.WrapErrorf(err, "Getting file info for '%s'", src)
-			}
-
-			if !fileInfo.IsDir() {
-				dstContainingDir := filepath.Dir(dst)
-				err := c.fs.MkdirAll(dstContainingDir, os.ModePerm)
-				if err != nil {
-					return bosherr.WrapErrorf(err, "Making destination directory '%s' for '%s'", dstContainingDir, src)
-				}
-
-				err = c.fs.CopyFile(src, dst)
-				if err != nil {
-					c.CleanUp(tempDir)
-					return err
-				}
-			}
-		}
-
-		err = os.Chmod(tempDir, os.FileMode(0755))
-		if err != nil {
-			bosherr.WrapError(err, "Fixing permissions on temp dir")
-		}
-
-		return nil
-	})
+	return c.FilteredMultiCopyToTemp([]DirToCopy{{Dir: dir}}, filters)
 }
 
-func (c genericCpCopier) tryInTempDir(fn func(string) error) (string, error) {
+func (c genericCpCopier) FilteredMultiCopyToTemp(dirs []DirToCopy, filters []string) (string, error) {
+	var err error
+
 	tempDir, err := c.fs.TempDir("bosh-platform-commands-cpCopier-FilteredCopyToTemp")
 	if err != nil {
 		return "", bosherr.WrapError(err, "Creating temporary directory")
 	}
 
-	err = fn(tempDir)
+	err = os.Chmod(tempDir, os.FileMode(0755))
 	if err != nil {
 		c.CleanUp(tempDir)
-		return "", err
+		bosherr.WrapError(err, "Fixing permissions on temp dir")
+	}
+
+	for _, dirToCopy := range dirs {
+		globsFiles := c.convertDirectoriesToGlobs(dirToCopy.Dir, filters)
+		var filesToCopy []string
+
+		for _, globFile := range globsFiles {
+			filteredFilesToCopy, err := doublestar.Glob(globFile)
+			if err != nil {
+				c.CleanUp(tempDir)
+				return "", bosherr.WrapError(err, "Finding files matching filters")
+			}
+
+			for _, fileToCopy := range filteredFilesToCopy {
+				filesToCopy = append(filesToCopy, strings.TrimPrefix(strings.TrimPrefix(fileToCopy, dirToCopy.Dir), "/"))
+			}
+		}
+
+		err = c.copyFilesToDir(filesToCopy, dirToCopy.Dir, tempDir, dirToCopy.Prefix)
+		if err != nil {
+			c.CleanUp(tempDir)
+			return "", bosherr.WrapError(err, "Copying Files to Temp Dir")
+		}
 	}
 
 	return tempDir, nil
@@ -99,6 +80,34 @@ func (c genericCpCopier) CleanUp(tempDir string) {
 	if err != nil {
 		c.logger.Error(genericCpCopierLogTag, "Failed to clean up temporary directory %s: %#v", tempDir, err)
 	}
+}
+
+func (c genericCpCopier) copyFilesToDir(fileList []string, srcDir string, destDir string, destPrefix string) error {
+	destDir = filepath.Join(destDir, destPrefix)
+
+	for _, relativePath := range fileList {
+		src := filepath.Join(srcDir, relativePath)
+		dst := filepath.Join(destDir, relativePath)
+
+		fileInfo, err := os.Stat(src)
+		if err != nil {
+			return bosherr.WrapErrorf(err, "Getting file info for '%s'", src)
+		}
+
+		if !fileInfo.IsDir() {
+			dstContainingDir := filepath.Dir(dst)
+			err := c.fs.MkdirAll(dstContainingDir, os.ModePerm)
+			if err != nil {
+				return bosherr.WrapErrorf(err, "Making destination directory '%s' for '%s'", dstContainingDir, src)
+			}
+
+			err = c.fs.CopyFile(src, dst)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (c genericCpCopier) convertDirectoriesToGlobs(dir string, filters []string) []string {
@@ -115,4 +124,3 @@ func (c genericCpCopier) convertDirectoriesToGlobs(dir string, filters []string)
 
 	return convertedFilters
 }
-


### PR DESCRIPTION
This will be used in the bosh-agent for the new functionality of capturing multiple types of logs (including system logs) in a single call.

We also changed the genericCpCopier to use the Copy function from the bosh-utils system package rather than reimplementing it separately.