### PR TITLE
Allow setting log_level for logger tags

### DIFF
--- a/logger/async.go
+++ b/logger/async.go
@@ -134,3 +134,7 @@ func (l *asyncLogger) ToggleForcedDebug() {
 func (l *asyncLogger) UseRFC3339Timestamps() {
 	l.log.UseRFC3339Timestamps()
 }
+
+func (l *asyncLogger) UseTags(tags []LogTag) {
+	l.log.UseTags(tags)
+}

--- a/logger/fakes/fake_logger.go
+++ b/logger/fakes/fake_logger.go
@@ -74,6 +74,11 @@ type FakeLogger struct {
 	toggleForcedDebugMutex       sync.RWMutex
 	toggleForcedDebugArgsForCall []struct {
 	}
+	UseTagsStub        func()
+	UseTagsMutex       sync.RWMutex
+	UseTagsArgsForCall []struct {
+		tags []logger.LogTag
+	}
 	UseRFC3339TimestampsStub        func()
 	useRFC3339TimestampsMutex       sync.RWMutex
 	useRFC3339TimestampsArgsForCall []struct {
@@ -418,6 +423,30 @@ func (fake *FakeLogger) ToggleForcedDebugCalls(stub func()) {
 	fake.toggleForcedDebugMutex.Lock()
 	defer fake.toggleForcedDebugMutex.Unlock()
 	fake.ToggleForcedDebugStub = stub
+}
+
+func (fake *FakeLogger) UseTags(tags []logger.LogTag) {
+	fake.UseTagsMutex.Lock()
+	fake.UseTagsArgsForCall = append(fake.UseTagsArgsForCall, struct {
+		tags []logger.LogTag
+	}{tags})
+	fake.recordInvocation("UseTags", []interface{}{tags})
+	fake.UseTagsMutex.Unlock()
+	if fake.UseTagsStub != nil {
+		fake.UseTagsStub()
+	}
+}
+
+func (fake *FakeLogger) UseTagsCallCount() int {
+	fake.UseTagsMutex.RLock()
+	defer fake.UseTagsMutex.RUnlock()
+	return len(fake.UseTagsArgsForCall)
+}
+
+func (fake *FakeLogger) UseTagsCalls(stub func()) {
+	fake.UseTagsMutex.Lock()
+	defer fake.UseTagsMutex.Unlock()
+	fake.UseTagsStub = stub
 }
 
 func (fake *FakeLogger) UseRFC3339Timestamps() {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -328,6 +328,28 @@ var _ = Describe("Logger", func() {
 		})
 	})
 
+	Describe("Enabling using tags with different log levels", func() {
+		Describe("when the log level is error", func() {
+			It("overwrites log level with that of used tag", func() {
+				logger := NewWriterLogger(LevelError, outBuf)
+
+				logger.UseTags([]LogTag{{"ForwardHandler", 0}})
+
+				logger.Debug("STANDARD_DEBUG", "some debug log")
+				logger.Info("STANDARD_INFO", "some info log")
+				logger.Warn("STANDARD_WARN", "some warn log")
+				logger.Error("STANDARD_ERROR", "some error log")
+				logger.Debug("ForwardHandler", "debug logs to show")
+
+				Expect(outBuf).ToNot(ContainSubstring("STANDARD_DEBUG"))
+				Expect(outBuf).ToNot(ContainSubstring("STANDARD_INFO"))
+				Expect(outBuf).ToNot(ContainSubstring("STANDARD_WARN"))
+				Expect(outBuf).To(ContainSubstring("STANDARD_ERROR"))
+				Expect(outBuf).To(ContainSubstring("ForwardHandler"))
+			})
+		})
+	})
+
 	It("does not block while printing a string", func() {
 		var slow slowGoStringer
 		logger := NewWriterLogger(LevelError, outBuf)

--- a/logger/loggerfakes/fake_logger.go
+++ b/logger/loggerfakes/fake_logger.go
@@ -74,6 +74,11 @@ type FakeLogger struct {
 	toggleForcedDebugMutex       sync.RWMutex
 	toggleForcedDebugArgsForCall []struct {
 	}
+	UseTagsStub        func()
+	UseTagsMutex       sync.RWMutex
+	UseTagsArgsForCall []struct {
+		tags []logger.LogTag
+	}
 	UseRFC3339TimestampsStub        func()
 	useRFC3339TimestampsMutex       sync.RWMutex
 	useRFC3339TimestampsArgsForCall []struct {
@@ -418,6 +423,30 @@ func (fake *FakeLogger) ToggleForcedDebugCalls(stub func()) {
 	fake.toggleForcedDebugMutex.Lock()
 	defer fake.toggleForcedDebugMutex.Unlock()
 	fake.ToggleForcedDebugStub = stub
+}
+
+func (fake *FakeLogger) UseTags(tags []logger.LogTag) {
+	fake.UseTagsMutex.Lock()
+	fake.UseTagsArgsForCall = append(fake.UseTagsArgsForCall, struct {
+		tags []logger.LogTag
+	}{tags})
+	fake.recordInvocation("UseTags", []interface{}{tags})
+	fake.UseTagsMutex.Unlock()
+	if fake.UseTagsStub != nil {
+		fake.UseTagsStub()
+	}
+}
+
+func (fake *FakeLogger) UseTagsCallCount() int {
+	fake.UseTagsMutex.RLock()
+	defer fake.UseTagsMutex.RUnlock()
+	return len(fake.UseTagsArgsForCall)
+}
+
+func (fake *FakeLogger) UseTagsCalls(stub func()) {
+	fake.UseTagsMutex.Lock()
+	defer fake.UseTagsMutex.Unlock()
+	fake.UseTagsStub = stub
 }
 
 func (fake *FakeLogger) UseRFC3339Timestamps() {


### PR DESCRIPTION
This feature allows a logger instance to useTags. It makes it possible to provide a list of pairs: tag_name, log_level in which a user can list all tags they are interested in and would be then used to overwrite the log_level of the logger if any message that is to be printed contain any of these tags.

For example: If by default the logger_level is ERROR and only ERROR messages are printed by the logger, a user can decide to logger.UseTags([]LogTag{{"ForwardHandler", 0}}) and with that, if any message is to be printed with a tag=ForwardHandler, the log_level: DEBUG is to be taken into account instead of ERROR.

Note: This PR is a perquisite to https://github.com/cloudfoundry/bosh-dns-release/pull/96   