### PR TITLE
fix for golang 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/bosh-utils
 
-go 1.21.0
+go 1.23.0
 
 require (
 	code.cloudfoundry.org/clock v1.0.0

--- a/httpclient/default_http_clients.go
+++ b/httpclient/default_http_clients.go
@@ -17,8 +17,11 @@ import (
 var (
 	DefaultClient            = CreateDefaultClientInsecureSkipVerify()
 	defaultDialerContextFunc = SOCKS5DialContextFuncFromEnvironment((&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
+		Timeout: 30 * time.Second,
+		KeepAliveConfig: net.KeepAliveConfig{
+			Enable:   true,
+			Interval: 30 * time.Second,
+		},
 	}), proxy.NewSocks5Proxy(proxy.NewHostKey(), log.New(io.Discard, "", log.LstdFlags), 1*time.Minute))
 )
 
@@ -56,8 +59,11 @@ func CreateDefaultClientInsecureSkipVerify() *http.Client {
 
 func ResetDialerContext() {
 	defaultDialerContextFunc = SOCKS5DialContextFuncFromEnvironment((&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
+		Timeout: 30 * time.Second,
+		KeepAliveConfig: net.KeepAliveConfig{
+			Enable:   true,
+			Interval: 30 * time.Second,
+		},
 	}), proxy.NewSocks5Proxy(proxy.NewHostKey(), log.New(io.Discard, "", log.LstdFlags), 1*time.Minute))
 }
 


### PR DESCRIPTION
Replace KeepAlive with KeepAliveConfig
Fixes
```
• [FAILED] [0.001 seconds]
Linux-specific tests [It] enables TCP (socket) keepalive with an appropriate interval
/tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-utils/httpclient/keepalive_syscall_linux_test.go:17

  [FAILED] Expected
      <int>: 15
  to equal
      <int>: 30
  In [It] at: /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-utils/httpclient/keepalive_syscall_linux_test.go:58 @ 09/03/24 14:42:33.858

  Full Stack Trace
    github.com/cloudfoundry/bosh-utils/httpclient_test.init.func3.1()
    	/tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-utils/httpclient/keepalive_syscall_linux_test.go:58 +0x81a
```