### PR TITLE
Match tar create behavior for header slashes

### DIFF
--- a/fileutil/tarball_compressor.go
+++ b/fileutil/tarball_compressor.go
@@ -76,6 +76,14 @@ func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string
 				header.Name = strings.ReplaceAll(relPath, "\\", forwardSlash)
 			}
 
+			if fi.IsDir() && header.Name[len(header.Name)-1:] != forwardSlash {
+				header.Name = header.Name + forwardSlash
+			}
+
+			if len(header.Name) < 2 || header.Name[0:2] != "."+forwardSlash {
+				header.Name = "." + forwardSlash + header.Name
+			}
+
 			if err := tw.WriteHeader(header); err != nil {
 				return bosherr.WrapError(err, "Writing tar header")
 			}

--- a/fileutil/tarball_compressor.go
+++ b/fileutil/tarball_compressor.go
@@ -80,8 +80,8 @@ func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string
 				header.Name = header.Name + forwardSlash
 			}
 
-			if len(header.Name) < 2 || header.Name[0:2] != "."+forwardSlash {
-				header.Name = "." + forwardSlash + header.Name
+			if len(header.Name) < 2 || header.Name[0:2] != fmt.Sprintf(".%s", forwardSlash) {
+				header.Name = fmt.Sprintf(".%s%s", forwardSlash, header.Name)
 			}
 
 			if err := tw.WriteHeader(header); err != nil {

--- a/fileutil/tarball_compressor_test.go
+++ b/fileutil/tarball_compressor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -140,26 +141,30 @@ var _ = Describe("tarballCompressor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove(tgzName)
 
-			_, _, _, err = cmdRunner.RunCommand("tar", "-xzpf", tgzName, "-C", dstDir)
+			tarballContents, _, _, err := cmdRunner.RunCommand("tar", "-tf", tgzName)
 			Expect(err).ToNot(HaveOccurred())
 
-			dstElements, err := pathsInDir(dstDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(dstElements).To(ConsistOf(
+			contentElements := strings.Fields(strings.TrimSpace(tarballContents))
+
+			Expect(contentElements).To(ConsistOf(
 				"./",
-				"app.stderr.log",
-				"app.stdout.log",
-				"other_logs/",
-				"some_directory/",
-				"some_directory/sub_dir/",
-				"some_directory/sub_dir/other_sub_dir/",
-				"some_directory/sub_dir/other_sub_dir/.keep",
-				"symlink_dir",
-				"other_logs/more_logs/",
-				"other_logs/other_app.stderr.log",
-				"other_logs/other_app.stdout.log",
-				"other_logs/more_logs/more.stdout.log",
+				"./.keep",
+				"./app.stderr.log",
+				"./app.stdout.log",
+				"./other_logs/",
+				"./some_directory/",
+				"./some_directory/sub_dir/",
+				"./some_directory/sub_dir/other_sub_dir/",
+				"./some_directory/sub_dir/other_sub_dir/.keep",
+				"./symlink_dir",
+				"./other_logs/more_logs/",
+				"./other_logs/other_app.stderr.log",
+				"./other_logs/other_app.stdout.log",
+				"./other_logs/more_logs/more.stdout.log",
 			))
+
+			_, _, _, err = cmdRunner.RunCommand("tar", "-xzpf", tgzName, "-C", dstDir)
+			Expect(err).ToNot(HaveOccurred())
 
 			content, err := fs.ReadFileString(filepath.FromSlash(dstDir + "/app.stdout.log"))
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This restores the spec for the tarball compressor to exactly match its previous behavior (from `tar` itself). Compressed files are prefixed with a ./, while directory entries contain a trailing slash.

While the implementation without slashes is equivalent, there are multiple tests across the ecosystem (notably BOSH Director integration specs) that have assertions about the old behavior.