### PR TITLE
Remove `UseIsolatedEnv` from `system.Command`

### DIFF
--- a/system/cmd_runner_interface.go
+++ b/system/cmd_runner_interface.go
@@ -6,10 +6,9 @@ import (
 )
 
 type Command struct {
-	Name           string
-	Args           []string
-	Env            map[string]string
-	UseIsolatedEnv bool
+	Name string
+	Args []string
+	Env  map[string]string
 
 	WorkingDir string
 

--- a/system/exec_cmd_runner.go
+++ b/system/exec_cmd_runner.go
@@ -3,7 +3,6 @@ package system
 import (
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
@@ -80,15 +79,7 @@ func (r execCmdRunner) buildComplexCommand(cmd Command) *exec.Cmd {
 
 	execCmd.Dir = cmd.WorkingDir
 
-	var env []string
-	if !cmd.UseIsolatedEnv {
-		env = os.Environ()
-	}
-	if cmd.UseIsolatedEnv && runtime.GOOS == "windows" {
-		panic("UseIsolatedEnv is not supported on Windows")
-	}
-
-	execCmd.Env = mergeEnv(env, cmd.Env)
+	execCmd.Env = mergeEnv(os.Environ(), cmd.Env)
 
 	return execCmd
 }

--- a/system/exec_cmd_runner_test.go
+++ b/system/exec_cmd_runner_test.go
@@ -130,7 +130,6 @@ var _ = Describe("execCmdRunner", func() {
 
 		It("run complex command with env", func() {
 			cmd := osSpecificCommand("env")
-			cmd.UseIsolatedEnv = false
 			stdout, stderr, status, err := runner.RunComplexCommand(cmd)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -139,23 +138,6 @@ var _ = Describe("execCmdRunner", func() {
 			Expect(envVars).To(HaveKey("PATH"))
 			Expect(stderr).To(BeEmpty())
 			Expect(status).To(Equal(0))
-		})
-
-		It("runs complex command with specific env", func() {
-			cmd := osSpecificCommand("env")
-			cmd.UseIsolatedEnv = true
-			if runtime.GOOS == "windows" {
-				Expect(func() { runner.RunComplexCommand(cmd) }).To(Panic()) //nolint:errcheck
-			} else {
-				stdout, stderr, status, err := runner.RunComplexCommand(cmd)
-				Expect(err).ToNot(HaveOccurred())
-
-				envVars := parseEnvFields(stdout, true)
-				Expect(envVars).To(HaveKeyWithValue("FOO", "BAR"))
-				Expect(envVars).ToNot(HaveKey("PATH"))
-				Expect(stderr).To(BeEmpty())
-				Expect(status).To(Equal(0))
-			}
 		})
 
 		It("uses the env vars specified in the Command", func() {
@@ -351,7 +333,6 @@ var _ = Describe("execCmdRunner", func() {
 
 		It("allows setting custom env variable in addition to inheriting process env variables", func() {
 			cmd := osSpecificCommand("env")
-			cmd.UseIsolatedEnv = false
 
 			process, err := runner.RunComplexCommandAsync(cmd)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This struct attribute is only ever set to `true` by the bosh-cli, and the value if this use case is in question, see:
- https://github.com/cloudfoundry/bosh-cli/issues/660
- https://github.com/cloudfoundry/bosh-cli/pull/663
- https://github.com/cloudfoundry/bosh-cli/pull/673

In addition the `UseIsolatedEnv` capability can be wholely handled within the `bosh-cli` codebase itself without the need for this featuer in `bosh-utils`.