### PR TITLE
Consolidate identical `newExecCmd()` implementations

### DIFF
--- a/system/exec_cmd_runner.go
+++ b/system/exec_cmd_runner.go
@@ -92,3 +92,7 @@ func (r execCmdRunner) buildComplexCommand(cmd Command) *exec.Cmd {
 
 	return execCmd
 }
+
+func newExecCmd(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
+}

--- a/system/exec_cmd_runner_unix.go
+++ b/system/exec_cmd_runner_unix.go
@@ -1,15 +1,11 @@
+//go:build !windows
 // +build !windows
 
 package system
 
 import (
-	"os/exec"
 	"strings"
 )
-
-func newExecCmd(name string, args ...string) *exec.Cmd {
-	return exec.Command(name, args...)
-}
 
 // mergeEnv merges system and command environments variables.  Command variables
 // override any system variable with the same key.

--- a/system/exec_cmd_runner_windows.go
+++ b/system/exec_cmd_runner_windows.go
@@ -1,14 +1,9 @@
 package system
 
 import (
-	"os/exec"
 	"sort"
 	"strings"
 )
-
-func newExecCmd(name string, args ...string) *exec.Cmd {
-	return exec.Command(name, args...)
-}
 
 // mergeEnv case-insensitive merge of system and command environments variables.
 // Command variables override any system variable with the same key.


### PR DESCRIPTION
These two implementations existed in the `unix` and `windows` variants of `exec_cmd_runner`. Perhaps they differed in the past but at present they are identical. This consolidates the two implementations into `exec_cmd_runner.go` from the respective OS-specific files.