### PR TITLE
Tar uncompress can accomodate paths w/ symlinks.

### DIFF
--- a/fileutil/fileutil_suite_test.go
+++ b/fileutil/fileutil_suite_test.go
@@ -59,10 +59,12 @@ func localCopyFSForGo122(dir string, fsys fs.FS) error {
 var _ = BeforeEach(func() {
 	assetsDirFS := os.DirFS(filepath.Join(".", "test_assets"))
 
-	testAssetsDir = GinkgoT().TempDir()
+	var err error
+	testAssetsDir, err = filepath.EvalSymlinks(GinkgoT().TempDir())
+	Expect(err).ToNot(HaveOccurred())
 
 	// TODO: use `os.CopyFS` instead of `localCopyFSForGo122` once we upgrade Golang versions
-	err := localCopyFSForGo122(testAssetsDir, assetsDirFS)
+	err = localCopyFSForGo122(testAssetsDir, assetsDirFS)
 	Expect(err).NotTo(HaveOccurred())
 
 	testAssetsFixtureDir = filepath.Join(testAssetsDir, "fixture_dir")

--- a/fileutil/tarball_compressor.go
+++ b/fileutil/tarball_compressor.go
@@ -57,7 +57,11 @@ func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, o
 		sameOwnerOption = "--same-owner"
 	}
 
-	args := []string{sameOwnerOption, "-xzf", tarballPath, "-C", dir}
+	resolvedTarballPath, err := c.fs.ReadAndFollowLink(tarballPath)
+	if err != nil {
+		return bosherr.WrapError(err, "Resolving tarball path")
+	}
+	args := []string{sameOwnerOption, "-xzf", resolvedTarballPath, "-C", dir}
 	if options.StripComponents != 0 {
 		args = append(args, fmt.Sprintf("--strip-components=%d", options.StripComponents))
 	}
@@ -65,7 +69,7 @@ func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, o
 	if options.PathInArchive != "" {
 		args = append(args, options.PathInArchive)
 	}
-	_, _, _, err := c.cmdRunner.RunCommand("tar", args...)
+	_, _, _, err = c.cmdRunner.RunCommand("tar", args...)
 	if err != nil {
 		return bosherr.WrapError(err, "Shelling out to tar")
 	}

--- a/fileutil/tarball_compressor_test.go
+++ b/fileutil/tarball_compressor_test.go
@@ -35,7 +35,9 @@ var _ = Describe("tarballCompressor", func() {
 		cmdRunner = boshsys.NewExecCmdRunner(logger)
 		fs = boshsys.NewOsFileSystem(logger)
 
-		dstDir = GinkgoT().TempDir()
+		var err error
+		dstDir, err = filepath.EvalSymlinks(GinkgoT().TempDir())
+		Expect(err).ToNot(HaveOccurred())
 		compressor = NewTarballCompressor(cmdRunner, fs)
 
 		fixtureSrcTgz = filepath.Join(testAssetsDir, "compressor-decompress-file-to-dir.tgz")

--- a/system/os_file_system_test.go
+++ b/system/os_file_system_test.go
@@ -58,7 +58,7 @@ var _ = Describe("OS FileSystem", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// If a regular user, the home directory will end with the username
-			expDir := fmt.Sprintf(`\%s`, filepath.Base(currentUser.Name))
+			expDir := fmt.Sprintf(`\%s`, filepath.Base(currentUser.Username))
 
 			// If a System or LocalSystem user, the home directory will be different
 			// ref: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers


### PR DESCRIPTION
- Windows recently changed such that System-user run processes receive C:\Windows\SystemTemp. In turn, the Windows 2019.x stemcell was updated such that C:\Windows\SystemTemp is a symlink to the boshTmpDir (`\var\vcap\data\tmp\` via bosh-agent changes).
- This behavior change subsequently caused bosh-utils tests to fail, since these tests attempt to extract tars to a path including a symlink, which tar does not permit.
- There are at least two ways to fix this problem: the bosh-utils test environment can arbitarily configure a temp directory that it "knows" does not include a symlink (e.g., by hard-coding to C:\Windows\Temp, which is NOT symlinked). An advantage here is behavior changes are limited to Windows behavior. A disadvantage is this shifts the responsibility for that tar extract destination paths do NOT include symlinks downstream. To be fair, downstream consumers have _ALWAYS_ had this responsibility, _however_, Windows behavior has changed such that it is almost certain that prior invocations of tar extraction with temp dirs that were previously successful will now fail. Alternatively, one can choose to change the tar uncompress behavior such that it will resolve the path _prior_ to an extraction. This has a larger impact in terms of change as it will also affect linux users, HOWEVER, this _should_ represent additive behavior to what consumers previously experienced. That is, current users of this method should be unaffected, including those users who would otherwise be impacted by the Windows stemcell changes. Further, I cannot currently imagine any previously valid invocations that would fail as a result of these changes, thus this latter change seems like a better choice, even given the behavior change.
- As mentioned above, this commit should fix any tar extraction issues observed in the DecompressFileToDir function after upgrading to the Windows 2019.87 stemcell. This change should be backwards compatible.