### PR TITLE
Fix flaky tests

### DIFF
--- a/logger/async_test.go
+++ b/logger/async_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Logger", func() {
 			const (
 				MessageCount  = 10
 				WriteInterval = 10 * time.Millisecond
-				Timeout       = WriteInterval * MessageCount * 10
+				Timeout       = WriteInterval * MessageCount * 100
 			)
 
 			out := &intervalWriter{dur: WriteInterval}


### PR DESCRIPTION
- http tests were relying on a 10ms timeout for connect and tls handshake. On slow enough machines this was causing flaky failures. Changed to a 10 second timeout by default, with the option for tests to use a client with a 1ms timeout if they are testing failure cases.

- asyc logging tests were expecting to finish within 10x the theoretical minimum time, which was good enough 999 out of 1000 times. 100x the theoretical minimum time seems to be good enough 1000 out of 1000 times.