### PR TITLE
Revert "Add NoCompression option to tarball compressor"

### DIFF
--- a/fileutil/compressor_interface.go
+++ b/fileutil/compressor_interface.go
@@ -4,14 +4,13 @@ type CompressorOptions struct {
 	SameOwner       bool
 	PathInArchive   string
 	StripComponents int
-	NoCompression   bool
 }
 
 type Compressor interface {
 	// CompressFilesInDir returns path to a compressed file
-	CompressFilesInDir(dir string, options CompressorOptions) (path string, err error)
+	CompressFilesInDir(dir string) (path string, err error)
 
-	CompressSpecificFilesInDir(dir string, files []string, options CompressorOptions) (path string, err error)
+	CompressSpecificFilesInDir(dir string, files []string) (path string, err error)
 
 	DecompressFileToDir(path string, dir string, options CompressorOptions) (err error)
 

--- a/fileutil/fakes/fake_compressor.go
+++ b/fileutil/fakes/fake_compressor.go
@@ -6,14 +6,12 @@ import (
 
 type FakeCompressor struct {
 	CompressFilesInDirDir         string
-	CompressFilesInDirOptions     boshcmd.CompressorOptions
 	CompressFilesInDirTarballPath string
 	CompressFilesInDirErr         error
 	CompressFilesInDirCallBack    func()
 
 	CompressSpecificFilesInDirDir         string
 	CompressSpecificFilesInDirFiles       []string
-	CompressSpecificFilesInDirOptions     boshcmd.CompressorOptions
 	CompressSpecificFilesInDirTarballPath string
 	CompressSpecificFilesInDirErr         error
 	CompressSpecificFilesInDirCallBack    func()
@@ -32,9 +30,9 @@ func NewFakeCompressor() *FakeCompressor {
 	return &FakeCompressor{}
 }
 
-func (fc *FakeCompressor) CompressFilesInDir(dir string, options boshcmd.CompressorOptions) (string, error) {
+func (fc *FakeCompressor) CompressFilesInDir(dir string) (string, error) {
 	fc.CompressFilesInDirDir = dir
-	fc.CompressFilesInDirOptions = options
+
 	if fc.CompressFilesInDirCallBack != nil {
 		fc.CompressFilesInDirCallBack()
 	}
@@ -42,10 +40,10 @@ func (fc *FakeCompressor) CompressFilesInDir(dir string, options boshcmd.Compres
 	return fc.CompressFilesInDirTarballPath, fc.CompressFilesInDirErr
 }
 
-func (fc *FakeCompressor) CompressSpecificFilesInDir(dir string, files []string, options boshcmd.CompressorOptions) (string, error) {
+func (fc *FakeCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
 	fc.CompressSpecificFilesInDirDir = dir
 	fc.CompressSpecificFilesInDirFiles = files
-	fc.CompressSpecificFilesInDirOptions = options
+
 	if fc.CompressSpecificFilesInDirCallBack != nil {
 		fc.CompressSpecificFilesInDirCallBack()
 	}

--- a/fileutil/tarball_compressor.go
+++ b/fileutil/tarball_compressor.go
@@ -20,11 +20,11 @@ func NewTarballCompressor(
 	return tarballCompressor{cmdRunner: cmdRunner, fs: fs}
 }
 
-func (c tarballCompressor) CompressFilesInDir(dir string, options CompressorOptions) (string, error) {
-	return c.CompressSpecificFilesInDir(dir, []string{"."}, options)
+func (c tarballCompressor) CompressFilesInDir(dir string) (string, error) {
+	return c.CompressSpecificFilesInDir(dir, []string{"."})
 }
 
-func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string, options CompressorOptions) (string, error) {
+func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
 	tarball, err := c.fs.TempFile("bosh-platform-disk-TarballCompressor-CompressSpecificFilesInDir")
 	if err != nil {
 		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
@@ -34,10 +34,7 @@ func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string
 
 	tarballPath := tarball.Name()
 
-	args := []string{"-cf", tarballPath, "-C", dir}
-	if !options.NoCompression {
-		args = append(args, "-z")
-	}
+	args := []string{"-czf", tarballPath, "-C", dir}
 	if runtime.GOOS == "darwin" {
 		args = append([]string{"--no-mac-metadata"}, args...)
 	}
@@ -64,7 +61,7 @@ func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, o
 	if err != nil {
 		return bosherr.WrapError(err, "Resolving tarball path")
 	}
-	args := []string{sameOwnerOption, "-xf", resolvedTarballPath, "-C", dir}
+	args := []string{sameOwnerOption, "-xzf", resolvedTarballPath, "-C", dir}
 	if options.StripComponents != 0 {
 		args = append(args, fmt.Sprintf("--strip-components=%d", options.StripComponents))
 	}

--- a/fileutil/tarball_compressor_test.go
+++ b/fileutil/tarball_compressor_test.go
@@ -53,7 +53,7 @@ var _ = Describe("tarballCompressor", func() {
 
 			defer os.Remove(symlinkPath)
 
-			tgzName, err := compressor.CompressFilesInDir(testAssetsFixtureDir, CompressorOptions{})
+			tgzName, err := compressor.CompressFilesInDir(testAssetsFixtureDir)
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove(tgzName)
 
@@ -94,30 +94,6 @@ var _ = Describe("tarballCompressor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(content).To(ContainSubstring("this is other app stdout"))
 		})
-
-		It("uses NoCompression option to create uncompressed tarball", func() {
-			cmdRunner := fakesys.NewFakeCmdRunner()
-			compressor := NewTarballCompressor(cmdRunner, fs)
-
-			tgzName, err := compressor.CompressFilesInDir(testAssetsFixtureDir, CompressorOptions{NoCompression: true})
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(tgzName)
-
-			Expect(1).To(Equal(len(cmdRunner.RunCommands)))
-			Expect(cmdRunner.RunCommands[0]).ToNot(ContainElement("-z"))
-		})
-
-		It("uses compression by default when NoCompression is false", func() {
-			cmdRunner := fakesys.NewFakeCmdRunner()
-			compressor := NewTarballCompressor(cmdRunner, fs)
-
-			tgzName, err := compressor.CompressFilesInDir(testAssetsFixtureDir, CompressorOptions{NoCompression: false})
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(tgzName)
-
-			Expect(1).To(Equal(len(cmdRunner.RunCommands)))
-			Expect(cmdRunner.RunCommands[0]).To(ContainElement("-z"))
-		})
 	})
 
 	Describe("CompressSpecificFilesInDir", func() {
@@ -128,7 +104,7 @@ var _ = Describe("tarballCompressor", func() {
 				"some_directory",
 				"app.stderr.log",
 			}
-			tgzName, err := compressor.CompressSpecificFilesInDir(srcDir, files, CompressorOptions{})
+			tgzName, err := compressor.CompressSpecificFilesInDir(srcDir, files)
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove(tgzName)
 
@@ -206,7 +182,7 @@ var _ = Describe("tarballCompressor", func() {
 			Expect(cmdRunner.RunCommands[0]).To(Equal(
 				[]string{
 					"tar", "--no-same-owner",
-					"-xf", tarballPath,
+					"-xzf", tarballPath,
 					"-C", dstDir,
 				},
 			))
@@ -228,7 +204,7 @@ var _ = Describe("tarballCompressor", func() {
 			Expect(cmdRunner.RunCommands[0]).To(Equal(
 				[]string{
 					"tar", "--same-owner",
-					"-xf", tarballPath,
+					"-xzf", tarballPath,
 					"-C", dstDir,
 				},
 			))
@@ -246,7 +222,7 @@ var _ = Describe("tarballCompressor", func() {
 			Expect(cmdRunner.RunCommands[0]).To(Equal(
 				[]string{
 					"tar", "--no-same-owner",
-					"-xf", tarballPath,
+					"-xzf", tarballPath,
 					"-C", dstDir,
 					"some/path/in/archive",
 				},
@@ -265,7 +241,7 @@ var _ = Describe("tarballCompressor", func() {
 			Expect(cmdRunner.RunCommands[0]).To(Equal(
 				[]string{
 					"tar", "--no-same-owner",
-					"-xf", tarballPath,
+					"-xzf", tarballPath,
 					"-C", dstDir,
 					"--strip-components=3",
 				},


### PR DESCRIPTION
Reverts cloudfoundry/bosh-utils#120

Let's unblock auto bumping of dependencies by reverting this change until the change in direction being discussed here: https://github.com/cloudfoundry/bosh-cli/pull/696#issuecomment-3437670344 has been realised. 