### PR TITLE
Add IsNonCompressedTarball method to Compressor interface

### DIFF
--- a/fileutil/compressor_interface.go
+++ b/fileutil/compressor_interface.go
@@ -15,6 +15,8 @@ type Compressor interface {
 
 	DecompressFileToDir(path string, dir string, options CompressorOptions) (err error)
 
+	IsNonCompressedTarball(path string) bool
+
 	// CleanUp cleans up compressed file after it was used
 	CleanUp(path string) error
 }

--- a/fileutil/fakes/fake_compressor.go
+++ b/fileutil/fakes/fake_compressor.go
@@ -24,6 +24,9 @@ type FakeCompressor struct {
 	DecompressFileToDirErr          error
 	DecompressFileToDirCallBack     func()
 
+	IsNonCompressedTarballPath    string
+	IsNonCompressedTarballReturns bool
+
 	CleanUpTarballPath string
 	CleanUpErr         error
 }
@@ -63,6 +66,11 @@ func (fc *FakeCompressor) DecompressFileToDir(tarballPath string, dir string, op
 	}
 
 	return fc.DecompressFileToDirErr
+}
+
+func (fc *FakeCompressor) IsNonCompressedTarball(path string) bool {
+	fc.IsNonCompressedTarballPath = path
+	return fc.IsNonCompressedTarballReturns
 }
 
 func (fc *FakeCompressor) CleanUp(tarballPath string) error {

--- a/fileutil/tarball_compressor.go
+++ b/fileutil/tarball_compressor.go
@@ -1,11 +1,22 @@
 package fileutil
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"runtime"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
+)
+
+var (
+	gzipMagic   = []byte{0x1f, 0x8b}
+	bzip2Magic  = []byte{0x42, 0x5a, 0x68} // "BZh"
+	xzMagic     = []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}
+	zstdMagic   = []byte{0x28, 0xb5, 0x2f, 0xfd}
+	ustarMagic  = []byte("ustar")
+	ustarOffset = 257 // Offset of the TAR magic string in the file
 )
 
 type tarballCompressor struct {
@@ -78,6 +89,39 @@ func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, o
 	}
 
 	return nil
+}
+
+func (c tarballCompressor) IsNonCompressedTarball(path string) bool {
+	f, err := c.fs.OpenFile(path, os.O_RDONLY, 0644)
+	if err != nil {
+		// If we cannot open the file, we assume it is not compressed
+		return false
+	}
+	defer f.Close() //nolint:errcheck
+
+	// Read the first 512 bytes to check both compression headers and the TAR header.
+	// Ignore the error from reading a partial buffer, which is fine for short files.
+	buffer := make([]byte, 512)
+	_, _ = f.Read(buffer) //nolint:errcheck
+
+	// 1. Check for compression first.
+	if bytes.HasPrefix(buffer, gzipMagic) ||
+		bytes.HasPrefix(buffer, bzip2Magic) ||
+		bytes.HasPrefix(buffer, xzMagic) ||
+		bytes.HasPrefix(buffer, zstdMagic) {
+		return false
+	}
+
+	// 2. If NOT compressed, check for the TAR magic string at its specific offset.
+	// Ensure the buffer is long enough to contain the TAR header magic string.
+	if len(buffer) > ustarOffset+len(ustarMagic) {
+		magicBytes := buffer[ustarOffset : ustarOffset+len(ustarMagic)]
+		if bytes.Equal(magicBytes, ustarMagic) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c tarballCompressor) CleanUp(tarballPath string) error {

--- a/fileutil/tarball_compressor_test.go
+++ b/fileutil/tarball_compressor_test.go
@@ -273,6 +273,26 @@ var _ = Describe("tarballCompressor", func() {
 		})
 	})
 
+	Describe("IsNonCompressedTarball", func() {
+		It("returns false for compressed tarball", func() {
+			tgzName, err := compressor.CompressFilesInDir(testAssetsFixtureDir, CompressorOptions{NoCompression: false})
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(tgzName)
+
+			result := compressor.IsNonCompressedTarball(tgzName)
+			Expect(result).To(BeFalse())
+		})
+
+		It("returns true for uncompressed tarball", func() {
+			tgzName, err := compressor.CompressFilesInDir(testAssetsFixtureDir, CompressorOptions{NoCompression: true})
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(tgzName)
+
+			result := compressor.IsNonCompressedTarball(tgzName)
+			Expect(result).To(BeTrue())
+		})
+	})
+
 	Describe("CleanUp", func() {
 		It("removes tarball path", func() {
 			fs := fakesys.NewFakeFileSystem()


### PR DESCRIPTION
- Add IsNonCompressedTarball method to Compressor interface
- Implement IsNonCompressedTarball in TarballCompressor to detect uncompressed tar files
- Add fake implementation in FakeCompressor for testing
- Add tests for IsNonCompressedTarball with compressed and uncompressed tarballs