### PR TITLE
ci: use registry image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -123,12 +123,26 @@ jobs:
         trigger: true
       - get: golang-release-image
         trigger: true
+      - task: build-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: bosh-utils-dockerfiles
+          outputs:
+            - name: image
+          params:
+            CONTEXT: bosh-utils-dockerfiles/ci/docker
+          run:
+            path: build
       - put: bosh-utils-image
-        inputs: detect
+        no_get: true
         params:
-          build: "bosh-utils-dockerfiles/ci/docker"
-        get_params:
-          skip_download: true
+          image: image/image.tar
 
 resources:
   - name: weekly
@@ -200,9 +214,10 @@ resources:
       initial_version: '0.0.500'
 
   - name: bosh-utils-image
-    type: docker-image
+    type: registry-image
     source:
       repository: bosh/utils
+      tag: latest
       username: ((docker.username))
       password: ((docker.password))
 
@@ -210,6 +225,7 @@ resources:
     type: registry-image
     source:
       repository: bosh/utils
+      tag: latest
       username: ((docker.username))
       password: ((docker.password))
 

--- a/ci/tasks/test-unit.yml
+++ b/ci/tasks/test-unit.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: bosh/utils
-
 inputs:
 - name: bosh-utils
 


### PR DESCRIPTION
docker-image is deprecated and can't push images anymore

also clean up tasks to not specify an image, they're already specified in the pipeline