### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/protect-master.yml
+++ b/.github/workflows/protect-master.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   check-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/bosh-utils/security/code-scanning/2](https://github.com/cloudfoundry/bosh-utils/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is not granted broader default permissions.  
Best fix here: set `permissions: {}` at the workflow root (or job level) because this job only runs shell commands and does not need repository/API access. This is the strictest least-privilege setting and preserves existing functionality.

Edit file **`.github/workflows/protect-master.yml`** by inserting the permissions block between the trigger (`on`) and `jobs` (or at top-level anywhere valid). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
