### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@ name: go
 on:
   push:
   pull_request:
+permissions:
+  contents: read
 jobs:
   verify: # <- name
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/bosh-utils/security/code-scanning/1](https://github.com/cloudfoundry/bosh-utils/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/go.yml`. The best minimal fix is at the workflow root so it applies to all jobs in this workflow unless overridden later. For this workflow, `contents: read` is the appropriate least-privilege baseline and satisfies CodeQL’s recommendation without changing existing functionality.

Change region:
- File: `.github/workflows/go.yml`
- Insert `permissions:` between the `on:` trigger block and `jobs:` block.

No imports, methods, or external definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
