### PR TITLE
docs: use Go name in test comment

### DIFF
--- a/fileutil/fileutil_suite_test.go
+++ b/fileutil/fileutil_suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeEach(func() {
 	testAssetsDir, err = filepath.EvalSymlinks(GinkgoT().TempDir())
 	Expect(err).ToNot(HaveOccurred())
 
-	// TODO: use `os.CopyFS` instead of `localCopyFSForGo122` once we upgrade Golang versions
+	// TODO: use `os.CopyFS` instead of `localCopyFSForGo122` once we upgrade Go versions
 	err = localCopyFSForGo122(testAssetsDir, assetsDirFS)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Summary
- Update a test comment to use the official language name `Go` instead of `Golang`.
## Verification
- Checked locally that the old `upgrade Golang versions` wording is gone and the intended `upgrade Go versions` wording is present.
- - Final diff contains only this comment wording change.